### PR TITLE
docs: add shared Eng1/Eng2 contract confirmation checklist

### DIFF
--- a/CONTRACT_CONFIRMATION_LIST.md
+++ b/CONTRACT_CONFIRMATION_LIST.md
@@ -34,7 +34,7 @@ Please confirm each item with explicit `✅ yes` / `❌ change needed`.
   - `attempted_at` (Number, unix seconds)
   - `http_status` (Number)
   - `response_time_ms` (Number)
-  - `error_message` (String)
+  - `error_message` (Optional String; for non-2xx outcomes contains the error description, omitted or empty string for successful 2xx attempts)
 - Attempt numbering starts at `1` and increments per delivery try.
 
 4. **`webhook_configs` Contract**
@@ -50,7 +50,7 @@ Please confirm each item with explicit `✅ yes` / `❌ change needed`.
   - `X-Webhook-Signature: sha256=<hex>`
   - `X-Webhook-Id: <event_id>`
   - `X-Webhook-Timestamp: <unix_seconds>`
-- Signature string format confirmed as `"{timestamp}.{payload}"`.
+- Signature input string is exactly `<X-Webhook-Timestamp header value> + "." + <raw request body JSON>`, e.g. `"1707840000.{\"order_id\":\"ord_123\"}"`.
 
 6. **Success/Retry/Exhaustion Rules**
 - `2xx` => success: record attempt, mark `delivered`, delete SQS message.
@@ -70,7 +70,12 @@ Please confirm each item with explicit `✅ yes` / `❌ change needed`.
 
 9. **Observability Contract**
 - Log format: JSON structured logging; each log line MUST be a single JSON object (see `PROJECT_DICTIONARY.md` examples).
-- Required structured log fields (minimum JSON properties): `event_id`, `customer_id`, `attempt_number`, `result`, `http_status`, `latency_ms`, `error`.
+- Log event types:
+  - **Delivery attempt log lines**: one log line per HTTP delivery attempt to a customer endpoint.
+  - **Non-delivery operational log lines**: other worker activity (for example: queue polling, configuration fetch, background maintenance).
+- Required structured log fields by event type:
+  - For **delivery attempt** log lines, the minimum JSON properties are: `event_id`, `customer_id`, `attempt_number`, `result`, `http_status`, `latency_ms`, `error`.
+  - For **non-delivery operational** log lines, include `event_id` and `customer_id` when they are known/applicable; fields that only make sense for HTTP delivery attempts (such as `http_status` and `latency_ms`) MAY be omitted or set to `null` when not applicable.
 - Required CloudWatch metrics (both teams MUST emit with these exact names):
   - `webhook.delivery.success` (count)
   - `webhook.delivery.failure` (count)
@@ -90,7 +95,18 @@ Please confirm each item with explicit `✅ yes` / `❌ change needed`.
   - Missing config
   - Inactive config
   - Duplicate SQS message handling
-- Pass criteria: correct DynamoDB state + correct SQS delete/non-delete behavior + expected logs.
+    - Precondition: `webhook_events` row for `event_id` already exists in DynamoDB with `status='delivered'`, a final `attempt_count` recorded, and `delivered_at` set.
+    - When a duplicate SQS message with the same `event_id` is received, the Eng2 worker MUST:
+      - Read the existing event from DynamoDB.
+      - Detect that the event is already in a terminal state (`status='delivered'` or non-retryable `status='failed'`).
+      - Skip any new HTTP delivery attempt (no outbound webhook call is made).
+      - Not create or update any delivery-attempt records (no increment to `attempt_count`; no change to `status` or `delivered_at`).
+    - Expected DynamoDB state after processing the duplicate:
+      - The existing `webhook_events` item for that `event_id` remains unchanged (`status`, `attempt_count`, and `delivered_at` are identical to the precondition).
+    - Expected SQS behavior:
+      - The duplicate SQS message is deleted after this no-op processing.
+      - No additional messages are enqueued and no DLQ entry is created solely due to the duplication.
+- Pass criteria: for each test case above (including duplicate SQS message handling), correct DynamoDB state + correct SQS delete/non-delete behavior + expected logs.
 
 11. **Ownership Boundaries**
 - Eng1 owns ingestion payload shape, event write, and enqueue behavior.


### PR DESCRIPTION
This pull request adds a comprehensive contract confirmation checklist for the webhook delivery system, ensuring both engineering teams (Eng1 and Eng2) are aligned on all critical integration details. The checklist covers message formats, database schemas, delivery protocols, retry logic, idempotency, observability, integration test requirements, ownership boundaries, and change control processes.