### PR TITLE
patch the separate tests on model.rs file

### DIFF
--- a/worker/src/model.rs
+++ b/worker/src/model.rs
@@ -78,32 +78,6 @@ impl Event {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn mark_failed_clears_next_retry_and_sets_status_failed() {
-        let created_at = 1_700_000_000_i64;
-        let mut event = Event::new(
-            "event-1".to_string(),
-            "customer-1".to_string(),
-            "payload".to_string(),
-            created_at,
-        );
-
-        // Put the event into a retry-scheduled state first.
-        let retry_at = created_at + 60;
-        event.mark_retry_scheduled(retry_at);
-        assert_eq!(event.status, EventStatus::Pending);
-        assert_eq!(event.next_retry_at, Some(retry_at));
-
-        // Now mark the event as failed and verify terminal state.
-        event.mark_failed();
-        assert_eq!(event.status, EventStatus::Failed);
-        assert_eq!(event.next_retry_at, None);
-    }
-}
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WebhookConfig {
     pub customer_id: String,
@@ -210,7 +184,27 @@ pub struct QueueMessage {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[test]
+    fn mark_failed_clears_next_retry_and_sets_status_failed() {
+        let created_at = 1_700_000_000_i64;
+        let mut event = Event::new(
+            "event-1".to_string(),
+            "customer-1".to_string(),
+            "payload".to_string(),
+            created_at,
+        );
 
+        // Put the event into a retry-scheduled state first.
+        let retry_at = created_at + 60;
+        event.mark_retry_scheduled(retry_at);
+        assert_eq!(event.status, EventStatus::Pending);
+        assert_eq!(event.next_retry_at, Some(retry_at));
+
+        // Now mark the event as failed and verify terminal state.
+        event.mark_failed();
+        assert_eq!(event.status, EventStatus::Failed);
+        assert_eq!(event.next_retry_at, None);
+    }
     #[test]
     fn event_serialization_round_trip() {
         let event = Event::new(


### PR DESCRIPTION
This pull request moves a unit test for the `Event` struct from one location in the file to another, grouping it with other tests under the main `tests` module. There are no functional code changes—only the organization of test code is affected.

Test organization improvements:

* Moved the `mark_failed_clears_next_retry_and_sets_status_failed` test from a dedicated `tests` module at the end of the `Event` implementation to the main `tests` module, consolidating all tests in one place for better maintainability. [[1]](diffhunk://#diff-59ef07e24f255f008fc019b49770828e808a3513ab8549ef62aaf2dc50057715L81-L106) [[2]](diffhunk://#diff-59ef07e24f255f008fc019b49770828e808a3513ab8549ef62aaf2dc50057715R187-R207)