### PR TITLE
feat(infra): finalize SAM deploy workflow and local env defaults

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,0 +1,3 @@
+export AWS_PROFILE="your-aws-profile"
+export AWS_REGION="us-west-2"
+export AWS_DEFAULT_REGION="$AWS_REGION"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,10 +1,10 @@
+---
 name: Rust CI
 
-on:
-  push:
-    branches: ["main"]
+"on":
   pull_request:
     branches: ["main"]
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
@@ -32,4 +32,3 @@ jobs:
 
       - name: Test
         run: cargo test --verbose
-

--- a/.github/workflows/sam.yml
+++ b/.github/workflows/sam.yml
@@ -1,0 +1,34 @@
+---
+name: SAM CI
+
+"on":
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  sam-and-rust-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache Rust deps
+        uses: Swatinem/rust-cache@v2
+
+      - name: Setup SAM CLI
+        uses: aws-actions/setup-sam@v2
+
+      - name: Validate SAM template
+        run: sam validate --lint
+
+      - name: Build SAM app
+        run: sam build

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ target/
 .env
 .env.*
 !.env.example
+.envrc
+!.envrc.example
 
 # Logs and runtime dumps
 *.log

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+build-IngestionFunction:
+	cargo build --release -p ingestion -p worker
+	mkdir -p "$(ARTIFACTS_DIR)"
+	cp "target/release/ingestion" "$(ARTIFACTS_DIR)/ingestion"
+	cp "target/release/worker" "$(ARTIFACTS_DIR)/worker"
+	printf '%s\n' '#!/bin/sh' \
+		'case "$$AWS_LAMBDA_FUNCTION_NAME" in' \
+		'  *worker*) exec /var/task/worker ;;' \
+		'  *) exec /var/task/ingestion ;;' \
+		'esac' > "$(ARTIFACTS_DIR)/bootstrap"
+	chmod +x "$(ARTIFACTS_DIR)/bootstrap"
+	chmod +x "$(ARTIFACTS_DIR)/ingestion"
+	chmod +x "$(ARTIFACTS_DIR)/worker"
+
+build-WorkerFunction:
+	cargo build --release -p ingestion -p worker
+	mkdir -p "$(ARTIFACTS_DIR)"
+	cp "target/release/ingestion" "$(ARTIFACTS_DIR)/ingestion"
+	cp "target/release/worker" "$(ARTIFACTS_DIR)/worker"
+	printf '%s\n' '#!/bin/sh' \
+		'case "$$AWS_LAMBDA_FUNCTION_NAME" in' \
+		'  *worker*) exec /var/task/worker ;;' \
+		'  *) exec /var/task/ingestion ;;' \
+		'esac' > "$(ARTIFACTS_DIR)/bootstrap"
+	chmod +x "$(ARTIFACTS_DIR)/bootstrap"
+	chmod +x "$(ARTIFACTS_DIR)/ingestion"
+	chmod +x "$(ARTIFACTS_DIR)/worker"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-build-IngestionFunction:
+.PHONY: package-rust-lambdas build-IngestionFunction build-WorkerFunction
+
+package-rust-lambdas:
 	cargo build --release -p ingestion -p worker
 	mkdir -p "$(ARTIFACTS_DIR)"
 	cp "target/release/ingestion" "$(ARTIFACTS_DIR)/ingestion"
@@ -12,16 +14,6 @@ build-IngestionFunction:
 	chmod +x "$(ARTIFACTS_DIR)/ingestion"
 	chmod +x "$(ARTIFACTS_DIR)/worker"
 
-build-WorkerFunction:
-	cargo build --release -p ingestion -p worker
-	mkdir -p "$(ARTIFACTS_DIR)"
-	cp "target/release/ingestion" "$(ARTIFACTS_DIR)/ingestion"
-	cp "target/release/worker" "$(ARTIFACTS_DIR)/worker"
-	printf '%s\n' '#!/bin/sh' \
-		'case "$$AWS_LAMBDA_FUNCTION_NAME" in' \
-		'  *worker*) exec /var/task/worker ;;' \
-		'  *) exec /var/task/ingestion ;;' \
-		'esac' > "$(ARTIFACTS_DIR)/bootstrap"
-	chmod +x "$(ARTIFACTS_DIR)/bootstrap"
-	chmod +x "$(ARTIFACTS_DIR)/ingestion"
-	chmod +x "$(ARTIFACTS_DIR)/worker"
+build-IngestionFunction: package-rust-lambdas
+
+build-WorkerFunction: package-rust-lambdas

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,18 @@
-.PHONY: package-rust-lambdas build-IngestionFunction build-WorkerFunction
+.PHONY: build-rust-binaries package-ingestion package-worker build-IngestionFunction build-WorkerFunction
 
-package-rust-lambdas:
+build-rust-binaries:
 	cargo build --release -p ingestion -p worker
+
+package-ingestion: build-rust-binaries
 	mkdir -p "$(ARTIFACTS_DIR)"
-	cp "target/release/ingestion" "$(ARTIFACTS_DIR)/ingestion"
-	cp "target/release/worker" "$(ARTIFACTS_DIR)/worker"
-	printf '%s\n' '#!/bin/sh' \
-		'case "$$AWS_LAMBDA_FUNCTION_NAME" in' \
-		'  *worker*) exec /var/task/worker ;;' \
-		'  *) exec /var/task/ingestion ;;' \
-		'esac' > "$(ARTIFACTS_DIR)/bootstrap"
+	cp "target/release/ingestion" "$(ARTIFACTS_DIR)/bootstrap"
 	chmod +x "$(ARTIFACTS_DIR)/bootstrap"
-	chmod +x "$(ARTIFACTS_DIR)/ingestion"
-	chmod +x "$(ARTIFACTS_DIR)/worker"
 
-build-IngestionFunction: package-rust-lambdas
+package-worker: build-rust-binaries
+	mkdir -p "$(ARTIFACTS_DIR)"
+	cp "target/release/worker" "$(ARTIFACTS_DIR)/bootstrap"
+	chmod +x "$(ARTIFACTS_DIR)/bootstrap"
 
-build-WorkerFunction: package-rust-lambdas
+build-IngestionFunction: package-ingestion
+
+build-WorkerFunction: package-worker

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 build-rust-binaries:
 	cargo build --release -p ingestion -p worker
+	rm -rf "$(ARTIFACTS_DIR)"
 
 package-ingestion: build-rust-binaries
 	mkdir -p "$(ARTIFACTS_DIR)"

--- a/samconfig.toml
+++ b/samconfig.toml
@@ -1,0 +1,10 @@
+version = 0.1
+
+[default.deploy.parameters]
+stack_name = "hooray-dev"
+region = "us-west-2"
+profile = "hooray-dev"
+confirm_changeset = true
+capabilities = "CAPABILITY_IAM"
+disable_rollback = false
+parameter_overrides = "Environment=dev SqsVisibilityTimeoutSeconds=60 SqsMaxReceiveCount=4"

--- a/template.yaml
+++ b/template.yaml
@@ -220,7 +220,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       FunctionName: !Sub "hooray-relay-ingestion-${Environment}"
-      CodeUri: ingestion/
+      CodeUri: .
       Handler: bootstrap   # Rust Lambda bootstrap binary name
       Timeout: 30
       MemorySize: 256
@@ -258,7 +258,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       FunctionName: !Sub "hooray-relay-worker-${Environment}"
-      CodeUri: worker/
+      CodeUri: .
       Handler: bootstrap
       Timeout: 55          # Must be < SqsVisibilityTimeoutSeconds
       MemorySize: 256

--- a/template.yaml
+++ b/template.yaml
@@ -218,6 +218,8 @@ Resources:
   # -------------------------------------------------------------------------
   IngestionFunction:
     Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: makefile
     Properties:
       FunctionName: !Sub "hooray-relay-ingestion-${Environment}"
       CodeUri: .
@@ -256,6 +258,8 @@ Resources:
   # -------------------------------------------------------------------------
   WorkerFunction:
     Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: makefile
     Properties:
       FunctionName: !Sub "hooray-relay-worker-${Environment}"
       CodeUri: .


### PR DESCRIPTION
- switch SAM functions to workspace CodeUri and root custom Makefile build targets
- add bootstrap dispatcher packaging for ingestion/worker binaries
- add samconfig.toml deploy defaults for hooray-dev
- ignore local .envrc and add .envrc.example template


This pull request introduces improvements to the AWS Lambda deployment workflow for the ingestion and worker functions. The main changes focus on build automation, deployment configuration, and environment setup, making the deployment process more streamlined and consistent.

**Build and deployment automation:**

- Added `build-IngestionFunction` and `build-WorkerFunction` targets to the `Makefile` to automate building both the `ingestion` and `worker` Rust binaries, copying them to the artifacts directory, and generating a `bootstrap` script to select the correct binary at runtime.
- Updated the `CodeUri` for both Lambda functions in `template.yaml` to point to the root directory (`.`) instead of subdirectories, aligning with the new build output structure. [[1]](diffhunk://#diff-1363ef5ce8886100842332c97163aad7934237e1fe49b5d40422b45fdc30f38eL223-R223) [[2]](diffhunk://#diff-1363ef5ce8886100842332c97163aad7934237e1fe49b5d40422b45fdc30f38eL261-R261)

**Deployment configuration:**

- Added a new `samconfig.toml` file to specify deployment parameters such as stack name, region, AWS profile, and CloudFormation capabilities for the AWS SAM CLI.

**Environment setup:**

- Updated `.envrc.example` to include example AWS environment variables for profile and region configuration.