### PR TITLE
feat(worker): complete day 2 dynamodb validation

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,3 +1,7 @@
 export AWS_PROFILE="your-aws-profile"
 export AWS_REGION="us-west-2"
 export AWS_DEFAULT_REGION="$AWS_REGION"
+
+# Worker DynamoDB tables (used by worker/tests/test_dynamodb.sh)
+export WEBHOOK_EVENTS_TABLE="webhook_events_dev"
+export WEBHOOK_CONFIGS_TABLE="webhook_configs_dev"

--- a/worker/src/services/dynamodb.rs
+++ b/worker/src/services/dynamodb.rs
@@ -305,3 +305,206 @@ impl DynamoDbService {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aws_config::BehaviorVersion;
+    use std::env;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn must_env(name: &str) -> String {
+        env::var(name).unwrap_or_else(|_| panic!("{} must be set for integration test", name))
+    }
+
+    fn now_unix_secs() -> i64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock is before unix epoch")
+            .as_secs() as i64
+    }
+
+    fn attr_s(item: &HashMap<String, AttributeValue>, key: &str) -> String {
+        match item.get(key) {
+            Some(AttributeValue::S(value)) => value.clone(),
+            _ => panic!("missing or invalid string attr: {}", key),
+        }
+    }
+
+    fn attr_n_u32(item: &HashMap<String, AttributeValue>, key: &str) -> u32 {
+        match item.get(key) {
+            Some(AttributeValue::N(value)) => value.parse::<u32>().expect("invalid u32 number attr"),
+            _ => panic!("missing or invalid number attr: {}", key),
+        }
+    }
+
+    fn attr_n_i64(item: &HashMap<String, AttributeValue>, key: &str) -> i64 {
+        match item.get(key) {
+            Some(AttributeValue::N(value)) => value.parse::<i64>().expect("invalid i64 number attr"),
+            _ => panic!("missing or invalid number attr: {}", key),
+        }
+    }
+
+    #[tokio::test]
+    #[ignore = "requires AWS credentials, network access, and DynamoDB tables from env"]
+    async fn validates_attempt_recording_and_event_updates() {
+        let events_table = must_env("WEBHOOK_EVENTS_TABLE");
+        let configs_table = must_env("WEBHOOK_CONFIGS_TABLE");
+        let _region = must_env("AWS_REGION");
+        let ts_now = now_unix_secs();
+        let unique = format!(
+            "{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock is before unix epoch")
+                .as_millis()
+        );
+        let event_id = format!("evt_service_test_{}", unique);
+        let customer_id = format!("cust_service_test_{}", unique);
+        let event_pk = format!("EVENT#{}", event_id);
+        let config_pk = format!("CUSTOMER#{}", customer_id);
+
+        let shared_config = aws_config::load_defaults(BehaviorVersion::latest()).await;
+        let client = Client::new(&shared_config);
+        let service = DynamoDbService::new(client.clone(), events_table.clone(), configs_table.clone());
+
+        client
+            .put_item()
+            .table_name(&events_table)
+            .condition_expression("attribute_not_exists(pk) AND attribute_not_exists(sk)")
+            .item("pk", AttributeValue::S(event_pk.clone()))
+            .item("sk", AttributeValue::S(Event::metadata_sk().to_string()))
+            .item("event_id", AttributeValue::S(event_id.clone()))
+            .item("customer_id", AttributeValue::S(customer_id.clone()))
+            .item(
+                "payload",
+                AttributeValue::S("{\"order_id\":\"ord_service_test\",\"amount\":42.0}".to_string()),
+            )
+            .item("status", AttributeValue::S("pending".to_string()))
+            .item("attempt_count", AttributeValue::N("0".to_string()))
+            .item("created_at", AttributeValue::N(ts_now.to_string()))
+            .send()
+            .await
+            .expect("seed event put-item should succeed");
+
+        client
+            .put_item()
+            .table_name(&configs_table)
+            .condition_expression("attribute_not_exists(pk) AND attribute_not_exists(sk)")
+            .item("pk", AttributeValue::S(config_pk.clone()))
+            .item("sk", AttributeValue::S(WebhookConfig::sk().to_string()))
+            .item("customer_id", AttributeValue::S(customer_id.clone()))
+            .item(
+                "url",
+                AttributeValue::S("https://webhook.site/service-test".to_string()),
+            )
+            .item("secret", AttributeValue::S("whsec_service_test".to_string()))
+            .item("max_retries", AttributeValue::N("3".to_string()))
+            .item("active", AttributeValue::Bool(true))
+            .item("created_at", AttributeValue::N(ts_now.to_string()))
+            .item("updated_at", AttributeValue::N(ts_now.to_string()))
+            .send()
+            .await
+            .expect("seed config put-item should succeed");
+
+        let mut event = service
+            .get_event(&event_id)
+            .await
+            .expect("get_event should return seeded event");
+        assert_eq!(event.attempt_count, 0);
+
+        event.attempt_count = 1;
+        service
+            .increment_attempt_count(&event)
+            .await
+            .expect("increment_attempt_count should update attempt_count");
+
+        let event_after_count = client
+            .get_item()
+            .table_name(&events_table)
+            .consistent_read(true)
+            .key("pk", AttributeValue::S(event_pk.clone()))
+            .key("sk", AttributeValue::S(Event::metadata_sk().to_string()))
+            .send()
+            .await
+            .expect("get_item should read updated event")
+            .item
+            .expect("event item should exist");
+        assert_eq!(attr_n_u32(&event_after_count, "attempt_count"), 1);
+
+        event.status = EventStatus::Failed;
+        event.next_retry_at = Some(ts_now + 60);
+        service
+            .update_event_status(&event)
+            .await
+            .expect("update_event_status should update status fields");
+
+        let event_after_status = client
+            .get_item()
+            .table_name(&events_table)
+            .consistent_read(true)
+            .key("pk", AttributeValue::S(event_pk.clone()))
+            .key("sk", AttributeValue::S(Event::metadata_sk().to_string()))
+            .send()
+            .await
+            .expect("get_item should read status-updated event")
+            .item
+            .expect("event item should exist");
+        assert_eq!(attr_s(&event_after_status, "status"), "failed");
+        assert_eq!(attr_n_i64(&event_after_status, "next_retry_at"), ts_now + 60);
+
+        let attempt = DeliveryAttempt::new(
+            event_id.clone(),
+            1,
+            ts_now + 5,
+            Some(500),
+            250,
+            Some("validation failure".to_string()),
+        );
+        service
+            .record_attempt(attempt)
+            .await
+            .expect("record_attempt should create attempt item");
+
+        let attempt_item = client
+            .get_item()
+            .table_name(&events_table)
+            .consistent_read(true)
+            .key("pk", AttributeValue::S(event_pk.clone()))
+            .key("sk", AttributeValue::S(Event::attempt_sk(1)))
+            .send()
+            .await
+            .expect("get_item should read attempt item")
+            .item
+            .expect("attempt item should exist");
+        assert_eq!(attr_n_u32(&attempt_item, "attempt_number"), 1);
+        assert_eq!(attr_n_i64(&attempt_item, "attempted_at"), ts_now + 5);
+        assert_eq!(attr_n_u32(&attempt_item, "http_status"), 500);
+        assert_eq!(attr_s(&attempt_item, "error_message"), "validation failure");
+
+        client
+            .delete_item()
+            .table_name(&events_table)
+            .key("pk", AttributeValue::S(event_pk.clone()))
+            .key("sk", AttributeValue::S(Event::metadata_sk().to_string()))
+            .send()
+            .await
+            .expect("cleanup metadata item should succeed");
+        client
+            .delete_item()
+            .table_name(&events_table)
+            .key("pk", AttributeValue::S(event_pk))
+            .key("sk", AttributeValue::S(Event::attempt_sk(1)))
+            .send()
+            .await
+            .expect("cleanup attempt item should succeed");
+        client
+            .delete_item()
+            .table_name(&configs_table)
+            .key("pk", AttributeValue::S(config_pk))
+            .key("sk", AttributeValue::S(WebhookConfig::sk().to_string()))
+            .send()
+            .await
+            .expect("cleanup config item should succeed");
+    }
+}

--- a/worker/src/services/dynamodb.rs
+++ b/worker/src/services/dynamodb.rs
@@ -406,8 +406,8 @@ mod tests {
                             .await
                         {
                             eprintln!(
-                                "cleanup guard: failed to delete {}/{} from {}: {}",
-                                "pk", "sk", item.table, err
+                                "cleanup guard: failed to delete pk/sk from {}: {}",
+                                item.table, err
                             );
                         }
                     }

--- a/worker/src/services/dynamodb.rs
+++ b/worker/src/services/dynamodb.rs
@@ -417,6 +417,15 @@ mod tests {
             .await
             .expect("seed config put-item should succeed");
 
+        let config = service
+            .get_config(&customer_id)
+            .await
+            .expect("get_config should return seeded config");
+        assert_eq!(config.customer_id, customer_id);
+        assert_eq!(config.url, "https://webhook.site/service-test");
+        assert_eq!(config.secret, "whsec_service_test");
+        assert_eq!(config.max_retries, 3);
+        assert!(config.active);
         let mut event = service
             .get_event(&event_id)
             .await
@@ -492,7 +501,7 @@ mod tests {
             .expect("attempt item should exist");
         assert_eq!(attr_n_u32(&attempt_item, "attempt_number"), 1);
         assert_eq!(attr_n_i64(&attempt_item, "attempted_at"), ts_now + 5);
-        assert_eq!(attr_n_u32(&attempt_item, "http_status"), 500);
+        assert_eq!(attr_n_u32(&attempt_item, "http_status") as u16, 500u16);
         assert_eq!(attr_s(&attempt_item, "error_message"), "validation failure");
 
         client

--- a/worker/src/services/dynamodb.rs
+++ b/worker/src/services/dynamodb.rs
@@ -333,14 +333,18 @@ mod tests {
 
     fn attr_n_u32(item: &HashMap<String, AttributeValue>, key: &str) -> u32 {
         match item.get(key) {
-            Some(AttributeValue::N(value)) => value.parse::<u32>().expect("invalid u32 number attr"),
+            Some(AttributeValue::N(value)) => {
+                value.parse::<u32>().expect("invalid u32 number attr")
+            }
             _ => panic!("missing or invalid number attr: {}", key),
         }
     }
 
     fn attr_n_i64(item: &HashMap<String, AttributeValue>, key: &str) -> i64 {
         match item.get(key) {
-            Some(AttributeValue::N(value)) => value.parse::<i64>().expect("invalid i64 number attr"),
+            Some(AttributeValue::N(value)) => {
+                value.parse::<i64>().expect("invalid i64 number attr")
+            }
             _ => panic!("missing or invalid number attr: {}", key),
         }
     }
@@ -366,7 +370,8 @@ mod tests {
 
         let shared_config = aws_config::load_defaults(BehaviorVersion::latest()).await;
         let client = Client::new(&shared_config);
-        let service = DynamoDbService::new(client.clone(), events_table.clone(), configs_table.clone());
+        let service =
+            DynamoDbService::new(client.clone(), events_table.clone(), configs_table.clone());
 
         client
             .put_item()
@@ -378,7 +383,9 @@ mod tests {
             .item("customer_id", AttributeValue::S(customer_id.clone()))
             .item(
                 "payload",
-                AttributeValue::S("{\"order_id\":\"ord_service_test\",\"amount\":42.0}".to_string()),
+                AttributeValue::S(
+                    "{\"order_id\":\"ord_service_test\",\"amount\":42.0}".to_string(),
+                ),
             )
             .item("status", AttributeValue::S("pending".to_string()))
             .item("attempt_count", AttributeValue::N("0".to_string()))
@@ -398,7 +405,10 @@ mod tests {
                 "url",
                 AttributeValue::S("https://webhook.site/service-test".to_string()),
             )
-            .item("secret", AttributeValue::S("whsec_service_test".to_string()))
+            .item(
+                "secret",
+                AttributeValue::S("whsec_service_test".to_string()),
+            )
             .item("max_retries", AttributeValue::N("3".to_string()))
             .item("active", AttributeValue::Bool(true))
             .item("created_at", AttributeValue::N(ts_now.to_string()))
@@ -451,7 +461,10 @@ mod tests {
             .item
             .expect("event item should exist");
         assert_eq!(attr_s(&event_after_status, "status"), "failed");
-        assert_eq!(attr_n_i64(&event_after_status, "next_retry_at"), ts_now + 60);
+        assert_eq!(
+            attr_n_i64(&event_after_status, "next_retry_at"),
+            ts_now + 60
+        );
 
         let attempt = DeliveryAttempt::new(
             event_id.clone(),

--- a/worker/src/services/dynamodb.rs
+++ b/worker/src/services/dynamodb.rs
@@ -506,11 +506,14 @@ mod tests {
             .expect("get_event should return seeded event");
         assert_eq!(event.attempt_count, 0);
 
+        // `increment_attempt_count` persists the current `attempt_count` field
+        // from the event into DynamoDB; the caller is responsible for updating
+        // `event.attempt_count` before calling it.
         event.attempt_count = 1;
         service
             .increment_attempt_count(&event)
             .await
-            .expect("increment_attempt_count should update attempt_count");
+            .expect("increment_attempt_count should persist updated attempt_count");
 
         let event_after_count = client
             .get_item()
@@ -576,7 +579,7 @@ mod tests {
             .expect("attempt item should exist");
         assert_eq!(attr_n_u32(&attempt_item, "attempt_number"), 1);
         assert_eq!(attr_n_i64(&attempt_item, "attempted_at"), ts_now + 5);
-        assert_eq!(attr_n_u32(&attempt_item, "http_status") as u16, 500u16);
+        assert_eq!(attr_n_u32(&attempt_item, "http_status"), 500u32);
         assert_eq!(attr_s(&attempt_item, "error_message"), "validation failure");
     }
 }

--- a/worker/src/services/dynamodb.rs
+++ b/worker/src/services/dynamodb.rs
@@ -349,6 +349,77 @@ mod tests {
         }
     }
 
+    struct CleanupItem {
+        table: String,
+        pk: String,
+        sk: String,
+    }
+
+    struct CleanupGuard {
+        client: Client,
+        items: Vec<CleanupItem>,
+    }
+
+    impl CleanupGuard {
+        fn new(client: Client) -> Self {
+            Self {
+                client,
+                items: Vec::new(),
+            }
+        }
+
+        fn track(&mut self, table: &str, pk: &str, sk: &str) {
+            self.items.push(CleanupItem {
+                table: table.to_string(),
+                pk: pk.to_string(),
+                sk: sk.to_string(),
+            });
+        }
+    }
+
+    impl Drop for CleanupGuard {
+        fn drop(&mut self) {
+            if self.items.is_empty() {
+                return;
+            }
+
+            let client = self.client.clone();
+            let items = std::mem::take(&mut self.items);
+            let join_handle = std::thread::spawn(move || {
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build();
+
+                let Ok(runtime) = runtime else {
+                    eprintln!("cleanup guard: failed to build Tokio runtime");
+                    return;
+                };
+
+                runtime.block_on(async move {
+                    for item in items.into_iter().rev() {
+                        if let Err(err) = client
+                            .delete_item()
+                            .table_name(&item.table)
+                            .key("pk", AttributeValue::S(item.pk))
+                            .key("sk", AttributeValue::S(item.sk))
+                            .send()
+                            .await
+                        {
+                            eprintln!(
+                                "cleanup guard: failed to delete {}/{} from {}: {}",
+                                "pk", "sk", item.table, err
+                            );
+                        }
+                    }
+                });
+            });
+
+            if join_handle.join().is_err() {
+                eprintln!("cleanup guard: cleanup thread panicked");
+            }
+        }
+    }
+
     #[tokio::test]
     #[ignore = "requires AWS credentials, network access, and DynamoDB tables from env"]
     async fn validates_attempt_recording_and_event_updates() {
@@ -372,6 +443,7 @@ mod tests {
         let client = Client::new(&shared_config);
         let service =
             DynamoDbService::new(client.clone(), events_table.clone(), configs_table.clone());
+        let mut cleanup = CleanupGuard::new(client.clone());
 
         client
             .put_item()
@@ -393,6 +465,7 @@ mod tests {
             .send()
             .await
             .expect("seed event put-item should succeed");
+        cleanup.track(&events_table, &event_pk, Event::metadata_sk());
 
         client
             .put_item()
@@ -416,6 +489,7 @@ mod tests {
             .send()
             .await
             .expect("seed config put-item should succeed");
+        cleanup.track(&configs_table, &config_pk, WebhookConfig::sk());
 
         let config = service
             .get_config(&customer_id)
@@ -487,6 +561,7 @@ mod tests {
             .record_attempt(attempt)
             .await
             .expect("record_attempt should create attempt item");
+        cleanup.track(&events_table, &event_pk, &Event::attempt_sk(1));
 
         let attempt_item = client
             .get_item()
@@ -503,30 +578,5 @@ mod tests {
         assert_eq!(attr_n_i64(&attempt_item, "attempted_at"), ts_now + 5);
         assert_eq!(attr_n_u32(&attempt_item, "http_status") as u16, 500u16);
         assert_eq!(attr_s(&attempt_item, "error_message"), "validation failure");
-
-        client
-            .delete_item()
-            .table_name(&events_table)
-            .key("pk", AttributeValue::S(event_pk.clone()))
-            .key("sk", AttributeValue::S(Event::metadata_sk().to_string()))
-            .send()
-            .await
-            .expect("cleanup metadata item should succeed");
-        client
-            .delete_item()
-            .table_name(&events_table)
-            .key("pk", AttributeValue::S(event_pk))
-            .key("sk", AttributeValue::S(Event::attempt_sk(1)))
-            .send()
-            .await
-            .expect("cleanup attempt item should succeed");
-        client
-            .delete_item()
-            .table_name(&configs_table)
-            .key("pk", AttributeValue::S(config_pk))
-            .key("sk", AttributeValue::S(WebhookConfig::sk().to_string()))
-            .send()
-            .await
-            .expect("cleanup config item should succeed");
     }
 }

--- a/worker/tests/test_dynamodb.sh
+++ b/worker/tests/test_dynamodb.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Day 2 DynamoDB smoke test for Engineer 2 worker service.
+# Creates test event/config items and verifies they can be fetched.
+
+: "${AWS_REGION:?AWS_REGION is required}"
+: "${WEBHOOK_EVENTS_TABLE:?WEBHOOK_EVENTS_TABLE is required}"
+: "${WEBHOOK_CONFIGS_TABLE:?WEBHOOK_CONFIGS_TABLE is required}"
+
+EVENT_ID="${EVENT_ID:-evt_test_$(date +%s)}"
+CUSTOMER_ID="${CUSTOMER_ID:-cust_test_$(date +%s)}"
+TS_NOW="$(date +%s)"
+
+EVENT_PK="EVENT#${EVENT_ID}"
+EVENT_SK="v0"
+CONFIG_PK="CUSTOMER#${CUSTOMER_ID}"
+CONFIG_SK="CONFIG"
+
+echo "[1/4] Writing test event to ${WEBHOOK_EVENTS_TABLE}"
+aws dynamodb put-item \
+  --region "$AWS_REGION" \
+  --table-name "$WEBHOOK_EVENTS_TABLE" \
+  --condition-expression "attribute_not_exists(pk) AND attribute_not_exists(sk)" \
+  --item "{
+    \"pk\": {\"S\": \"${EVENT_PK}\"},
+    \"sk\": {\"S\": \"${EVENT_SK}\"},
+    \"event_id\": {\"S\": \"${EVENT_ID}\"},
+    \"customer_id\": {\"S\": \"${CUSTOMER_ID}\"},
+    \"payload\": {\"S\": \"{\\\"order_id\\\":\\\"ord_test\\\",\\\"amount\\\":99.99}\"},
+    \"status\": {\"S\": \"pending\"},
+    \"attempt_count\": {\"N\": \"0\"},
+    \"created_at\": {\"N\": \"${TS_NOW}\"}
+  }"
+
+echo "[2/4] Writing test config to ${WEBHOOK_CONFIGS_TABLE}"
+aws dynamodb put-item \
+  --region "$AWS_REGION" \
+  --table-name "$WEBHOOK_CONFIGS_TABLE" \
+  --condition-expression "attribute_not_exists(pk) AND attribute_not_exists(sk)" \
+  --item "{
+    \"pk\": {\"S\": \"${CONFIG_PK}\"},
+    \"sk\": {\"S\": \"${CONFIG_SK}\"},
+    \"customer_id\": {\"S\": \"${CUSTOMER_ID}\"},
+    \"url\": {\"S\": \"https://webhook.site/example\"},
+    \"secret\": {\"S\": \"whsec_test_secret\"},
+    \"max_retries\": {\"N\": \"3\"},
+    \"active\": {\"BOOL\": true},
+    \"created_at\": {\"N\": \"${TS_NOW}\"},
+    \"updated_at\": {\"N\": \"${TS_NOW}\"}
+  }"
+
+echo "[3/4] Fetching event by pk/sk"
+EVENT_ID_FETCHED="$(aws dynamodb get-item \
+  --consistent-read \
+  --region "$AWS_REGION" \
+  --table-name "$WEBHOOK_EVENTS_TABLE" \
+  --key "{\"pk\":{\"S\":\"${EVENT_PK}\"},\"sk\":{\"S\":\"${EVENT_SK}\"}}" \
+  --query 'Item.event_id.S' \
+  --output text)"
+
+echo "[4/4] Fetching config by pk/sk"
+CONFIG_CUSTOMER_ID_FETCHED="$(aws dynamodb get-item \
+  --consistent-read \
+  --region "$AWS_REGION" \
+  --table-name "$WEBHOOK_CONFIGS_TABLE" \
+  --key "{\"pk\":{\"S\":\"${CONFIG_PK}\"},\"sk\":{\"S\":\"${CONFIG_SK}\"}}" \
+  --query 'Item.customer_id.S' \
+  --output text)"
+
+if [[ "$EVENT_ID_FETCHED" != "$EVENT_ID" ]]; then
+  echo "ERROR: event fetch mismatch expected=${EVENT_ID} got=${EVENT_ID_FETCHED}"
+  exit 1
+fi
+
+if [[ "$CONFIG_CUSTOMER_ID_FETCHED" != "$CUSTOMER_ID" ]]; then
+  echo "ERROR: config fetch mismatch expected=${CUSTOMER_ID} got=${CONFIG_CUSTOMER_ID_FETCHED}"
+  exit 1
+fi
+
+echo "SUCCESS: DynamoDB test data created and fetch verified"
+echo "EVENT_ID=${EVENT_ID} CUSTOMER_ID=${CUSTOMER_ID}"

--- a/worker/tests/test_dynamodb.sh
+++ b/worker/tests/test_dynamodb.sh
@@ -8,8 +8,8 @@ set -euo pipefail
 : "${WEBHOOK_EVENTS_TABLE:?WEBHOOK_EVENTS_TABLE is required}"
 : "${WEBHOOK_CONFIGS_TABLE:?WEBHOOK_CONFIGS_TABLE is required}"
 
-EVENT_ID="${EVENT_ID:-evt_test_$(date +%s)}"
-CUSTOMER_ID="${CUSTOMER_ID:-cust_test_$(date +%s)}"
+EVENT_ID="${EVENT_ID:-evt_test_$(date +%s%N)}"
+CUSTOMER_ID="${CUSTOMER_ID:-cust_test_$(date +%s%N)}"
 TS_NOW="$(date +%s)"
 
 EVENT_PK="EVENT#${EVENT_ID}"
@@ -80,3 +80,17 @@ fi
 
 echo "SUCCESS: DynamoDB test data created and fetch verified"
 echo "EVENT_ID=${EVENT_ID} CUSTOMER_ID=${CUSTOMER_ID}"
+
+echo "[CLEANUP] Deleting test event from ${WEBHOOK_EVENTS_TABLE}"
+aws dynamodb delete-item \
+  --region "$AWS_REGION" \
+  --table-name "$WEBHOOK_EVENTS_TABLE" \
+  --key "{\"pk\":{\"S\":\"${EVENT_PK}\"},\"sk\":{\"S\":\"${EVENT_SK}\"}}"
+
+echo "[CLEANUP] Deleting test config from ${WEBHOOK_CONFIGS_TABLE}"
+aws dynamodb delete-item \
+  --region "$AWS_REGION" \
+  --table-name "$WEBHOOK_CONFIGS_TABLE" \
+  --key "{\"pk\":{\"S\":\"${CONFIG_PK}\"},\"sk\":{\"S\":\"${CONFIG_SK}\"}}"
+
+echo "CLEANUP: Test items deleted from DynamoDB tables"

--- a/worker/tests/test_dynamodb.sh
+++ b/worker/tests/test_dynamodb.sh
@@ -16,6 +16,45 @@ EVENT_PK="EVENT#${EVENT_ID}"
 EVENT_SK="v0"
 CONFIG_PK="CUSTOMER#${CUSTOMER_ID}"
 CONFIG_SK="CONFIG"
+KEEP_TEST_DATA="${KEEP_TEST_DATA:-false}"
+EVENT_WRITTEN=false
+CONFIG_WRITTEN=false
+
+cleanup() {
+  local exit_code=$?
+  set +e
+
+  if [[ "$KEEP_TEST_DATA" == "true" ]]; then
+    echo "[CLEANUP] KEEP_TEST_DATA=true, skipping item deletion"
+    return "$exit_code"
+  fi
+
+  if [[ "$EVENT_WRITTEN" == "true" ]]; then
+    echo "[CLEANUP] Deleting test event from ${WEBHOOK_EVENTS_TABLE}"
+    aws dynamodb delete-item \
+      --region "$AWS_REGION" \
+      --table-name "$WEBHOOK_EVENTS_TABLE" \
+      --key "{\"pk\":{\"S\":\"${EVENT_PK}\"},\"sk\":{\"S\":\"${EVENT_SK}\"}}" \
+      >/dev/null 2>&1 || echo "[CLEANUP] WARN: failed to delete event item"
+  fi
+
+  if [[ "$CONFIG_WRITTEN" == "true" ]]; then
+    echo "[CLEANUP] Deleting test config from ${WEBHOOK_CONFIGS_TABLE}"
+    aws dynamodb delete-item \
+      --region "$AWS_REGION" \
+      --table-name "$WEBHOOK_CONFIGS_TABLE" \
+      --key "{\"pk\":{\"S\":\"${CONFIG_PK}\"},\"sk\":{\"S\":\"${CONFIG_SK}\"}}" \
+      >/dev/null 2>&1 || echo "[CLEANUP] WARN: failed to delete config item"
+  fi
+
+  if [[ "$EVENT_WRITTEN" == "true" || "$CONFIG_WRITTEN" == "true" ]]; then
+    echo "[CLEANUP] Completed cleanup (exit_code=${exit_code})"
+  fi
+
+  return "$exit_code"
+}
+
+trap cleanup EXIT INT TERM
 
 echo "[1/4] Writing test event to ${WEBHOOK_EVENTS_TABLE}"
 aws dynamodb put-item \
@@ -32,6 +71,7 @@ aws dynamodb put-item \
     \"attempt_count\": {\"N\": \"0\"},
     \"created_at\": {\"N\": \"${TS_NOW}\"}
   }"
+EVENT_WRITTEN=true
 
 echo "[2/4] Writing test config to ${WEBHOOK_CONFIGS_TABLE}"
 aws dynamodb put-item \
@@ -49,6 +89,7 @@ aws dynamodb put-item \
     \"created_at\": {\"N\": \"${TS_NOW}\"},
     \"updated_at\": {\"N\": \"${TS_NOW}\"}
   }"
+CONFIG_WRITTEN=true
 
 echo "[3/4] Fetching event by pk/sk"
 EVENT_ID_FETCHED="$(aws dynamodb get-item \
@@ -80,17 +121,3 @@ fi
 
 echo "SUCCESS: DynamoDB test data created and fetch verified"
 echo "EVENT_ID=${EVENT_ID} CUSTOMER_ID=${CUSTOMER_ID}"
-
-echo "[CLEANUP] Deleting test event from ${WEBHOOK_EVENTS_TABLE}"
-aws dynamodb delete-item \
-  --region "$AWS_REGION" \
-  --table-name "$WEBHOOK_EVENTS_TABLE" \
-  --key "{\"pk\":{\"S\":\"${EVENT_PK}\"},\"sk\":{\"S\":\"${EVENT_SK}\"}}"
-
-echo "[CLEANUP] Deleting test config from ${WEBHOOK_CONFIGS_TABLE}"
-aws dynamodb delete-item \
-  --region "$AWS_REGION" \
-  --table-name "$WEBHOOK_CONFIGS_TABLE" \
-  --key "{\"pk\":{\"S\":\"${CONFIG_PK}\"},\"sk\":{\"S\":\"${CONFIG_SK}\"}}"
-
-echo "CLEANUP: Test items deleted from DynamoDB tables"


### PR DESCRIPTION
This pull request adds comprehensive integration and smoke tests for DynamoDB operations in the worker service. The main focus is to ensure that event and configuration items can be created, updated, fetched, and cleaned up correctly in DynamoDB, both through Rust integration tests and a Bash smoke test script.

**Testing improvements:**

* Added a Rust integration test module to `worker/src/services/dynamodb.rs` that seeds test data, verifies event/config creation, updates, and cleans up, covering the main DynamoDB service methods.
* Introduced a Bash smoke test script `test_dynamodb.sh` that creates and fetches test items in DynamoDB to quickly verify connectivity and table correctness.