### PR TITLE
docs/e2e: add full ingestion->worker runbook and local deploy workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,10 @@ coverage/
 
 # Lambda/SAM local artifacts
 .aws-sam/
+
+# Local SAM deploy config overrides
+samconfig.local.toml
+
+# Local Zig caches (used by cargo-lambda cross-compilation)
+.zig-cache/
+.zig-global-cache/

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -20,7 +20,7 @@ All tools confirmed installed and working on this machine:
 
 ### `samconfig.toml`
 
-Pre-configured deployment defaults (committed, do not edit locally):
+Pre-configured shared defaults (committed, safe for CI):
 
 ```toml
 version = 0.1
@@ -30,9 +30,18 @@ stack_name        = "hooray-dev"
 region            = "us-west-2"
 profile           = "hooray-dev"     # ← AWS profile name (see Step 3b)
 confirm_changeset = true
-capabilities      = "CAPABILITY_IAM"
+capabilities      = "CAPABILITY_IAM CAPABILITY_NAMED_IAM"
 disable_rollback  = false
-parameter_overrides = "Environment=dev SqsVisibilityTimeoutSeconds=60 SqsMaxReceiveCount=4"
+parameter_overrides = "Environment=dev SqsVisibilityTimeoutSeconds=60 SqsMaxReceiveCount=4 EnableEcsWorker=false"
+```
+
+### `samconfig.local.toml` (local only)
+
+Account-specific ECS values should live in local config, not in committed config.
+
+```bash
+cp samconfig.local.toml.example samconfig.local.toml
+# Edit WorkerImageUri, EcsSubnetIds, EcsSecurityGroupIds, and profile as needed.
 ```
 
 ### `template.yaml`
@@ -48,16 +57,16 @@ SAM template that provisions all AWS infrastructure on deploy:
 | `webhook_delivery_dlq_dev` | SQS DLQ | 14-day retention |
 | `DLQDepthAlarm` | CloudWatch | Fires when DLQ depth > 0 |
 | `IngestionFunction` | Lambda | arm64/al2023, built from `ingestion/` |
-| `WorkerFunction` | Lambda | arm64/al2023, built from `worker/` |
 
 ### `Makefile`
 
 ```makefile
-build-IngestionFunction:  # cargo build -p ingestion → $ARTIFACTS_DIR/bootstrap
-build-WorkerFunction:     # cargo build -p worker    → $ARTIFACTS_DIR/bootstrap
+build-IngestionFunction:  # cargo lambda build -p ingestion --arm64 → $ARTIFACTS_DIR/bootstrap
+package-worker:           # cargo build -p worker --release (non-Lambda runtime)
 ```
 
-`sam build` calls these automatically — no manual `cargo` invocation needed.
+`sam build` calls `build-IngestionFunction` automatically.
+The worker is not deployed via SAM as Lambda in the current architecture.
 
 ### `.envrc.example`
 
@@ -119,7 +128,6 @@ source "$HOME/.cargo/env"
 sam build
 # Expected: "Build Succeeded"
 # Artifacts: .aws-sam/build/IngestionFunction/bootstrap
-#            .aws-sam/build/WorkerFunction/bootstrap
 ```
 
 ### Step 3e — First deploy ⏳ PENDING
@@ -152,9 +160,80 @@ Expected outputs: `EventsTableName`, `IdempotencyTableName`, `ConfigsTableName`,
 sam build && sam deploy
 ```
 
----
+For ECS worker-enabled deploys (local/dev), use local overrides:
 
-## 5. Running Tests Locally (No AWS Credentials Required)
+```bash
+./scripts/deploy_dev.sh
+```
+
+This script uses `samconfig.local.toml` and keeps account-specific values out of CI.
+
+### Known-Good ECS Deploy Checklist (validated on February 26, 2026)
+
+1. Ensure worker image tag exists in ECR.
+
+```bash
+aws ecr describe-images \
+  --region us-west-2 \
+  --repository-name hooray-relay-worker-dev \
+  --image-ids imageTag=<IMAGE_TAG>
+```
+
+2. Set `WorkerImageUri` in `samconfig.local.toml` to that exact tag.
+
+3. Deploy with local config:
+
+```bash
+./scripts/deploy_dev.sh
+```
+
+4. Verify ECS service health:
+
+```bash
+aws ecs describe-services \
+  --region us-west-2 \
+  --profile hooray-dev \
+  --cluster hooray-relay-worker-dev \
+  --services hooray-relay-worker-dev \
+  --query "services[0].{desired:desiredCount,running:runningCount,pending:pendingCount,rollout:deployments[0].rolloutState}" \
+  --output table
+```
+
+Expected result: `desired=1`, `running=1`, `pending=0`, `rollout=COMPLETED`.
+
+## 5. Worker Deployment (ECS/Fargate Recommended)
+
+Default recommendation: deploy worker container on ECS/Fargate.
+
+Build worker binary locally (optional local validation):
+
+```bash
+cargo build --release -p worker --bin worker
+```
+
+Run worker:
+
+```bash
+RUST_LOG=info ./target/release/worker
+```
+
+Required worker environment variables:
+- `AWS_REGION`
+- `QUEUE_URL` (or `WEBHOOK_QUEUE_URL`)
+- `EVENTS_TABLE` (or `WEBHOOK_EVENTS_TABLE`)
+- `CONFIGS_TABLE` (or `WEBHOOK_CONFIGS_TABLE`)
+
+Container build file:
+- `worker/Dockerfile`
+
+Primary rollout steps (ECS):
+1. Build + push image to ECR.
+2. Create ECS task definition with required env vars and IAM task role.
+3. Run ECS service (desired count `1` for MVP), then add autoscaling by SQS depth.
+
+See `docs/WORKER_RUNTIME.md` for exact commands and e2e checks.
+
+## 6. Running Tests Locally (No AWS Credentials Required)
 
 ```bash
 source "$HOME/.cargo/env"

--- a/docs/ENGINEER_1_TIMELINE.md
+++ b/docs/ENGINEER_1_TIMELINE.md
@@ -18,7 +18,7 @@
 **Morning (9am-12pm): AWS Setup**
 - [ ] Create AWS SAM project structure
 - [ ] Create `template.yaml` with DynamoDB tables, SQS queue, Lambda function placeholders
-- [ ] Deploy infrastructure with `sam deploy --guided`
+- [ ] Deploy infrastructure with `sam build && sam deploy --resolve-s3`
 - [ ] Verify all resources created successfully
 
 **Afternoon (1pm-5pm): Rust Project Setup**
@@ -131,7 +131,7 @@
 
 **Morning (9am-12pm): Integration Tests**
 - [ ] Create `tests/integration_test.sh` script
-- [ ] Deploy to AWS with `cargo lambda build` and `sam deploy`
+- [ ] Deploy to AWS with `sam build` and `sam deploy --resolve-s3`
 - [ ] Run integration tests against deployed API
 - [ ] Verify:
   - Config creation works

--- a/docs/ENGINEER_2_TIMELINE.md
+++ b/docs/ENGINEER_2_TIMELINE.md
@@ -127,7 +127,7 @@
 
 ### Day 4: SQS Polling & Main Worker Loop
 
-**Goal:** Build the main worker that polls SQS and orchestrates delivery
+**Goal:** Build the main worker service that polls SQS and orchestrates delivery
 
 **Morning (9am-12pm): Worker Structure**
 - [ ] Create `src/main.rs` with Worker struct
@@ -169,41 +169,50 @@
 
 ### Day 5: Integration Testing & Handoff
 
-**Goal:** Test integration with Engineer 1's components and coordinate handoff
+**Goal:** Test integration with Engineer 1's components and deploy the worker as a long-running service
 
 **Morning (9am-12pm): Integration Testing**
 - [ ] Meet with Engineer 1 for integration sync
 - [ ] Verify SQS message format matches expectations
 - [ ] Confirm DynamoDB schemas are correct
-- [ ] Create `tests/end_to_end_test.sh`:
-  - Create test event in DynamoDB
-  - Create webhook config
-  - Send message to SQS
-  - Verify worker processes it
+- [ ] Create `scripts/e2e_ingestion_worker.sh`:
+  - Create webhook config through ingestion API
+  - Submit event through ingestion API
+  - Verify worker writes `ATTEMPT#1`
+  - Verify final event status is `delivered`
+  - Add cleanup for event/config/idempotency test data
 - [ ] Test with real events from Engineer 1's API
 - [ ] Document any issues found
 
-**Afternoon (1pm-5pm): Deploy and Monitor**
-- [ ] Add WorkerFunction to `template.yaml`:
-  - SQS event source
-  - DynamoDB permissions
-  - Environment variables
-- [ ] Build Lambda: `cargo lambda build --release --arm64`
-- [ ] Deploy: `sam build && sam deploy`
-- [ ] Monitor logs: `sam logs --name WorkerFunction --tail`
+**Afternoon (1pm-5pm): Run Worker Service and Monitor**
+- [ ] Prepare runtime environment:
+  - Confirm AWS credentials/profile can access SQS + DynamoDB
+  - Confirm `QUEUE_URL`, `EVENTS_TABLE`, `CONFIGS_TABLE`, `AWS_REGION`
+- [ ] Build and push worker image:
+  - Build image from `worker/Dockerfile`
+  - Push to ECR
+  - Update `WorkerImageUri` tag in `samconfig.local.toml`
+- [ ] Deploy worker ECS service:
+  - Confirm `samconfig.local.toml` has valid `EcsSubnetIds` and `EcsSecurityGroupIds`
+  - Run `./scripts/deploy_dev.sh`
+- [ ] Monitor ECS and logs:
+  - Confirm ECS service/task reaches steady state
+  - Check CloudWatch log group `/ecs/hooray-relay-worker-dev`
+  - Monitor CloudWatch queue metrics
 - [ ] Verify deliveries to webhook.site
 - [ ] Check DynamoDB for delivery attempts
 - [ ] Confirm SQS messages being deleted
+- [ ] Confirm DLQ depth is not increasing during happy-path tests
 - [ ] Write integration test results document
 
 **Deliverables:**
 - Integration with Engineer 1 successful
 - All tests passing
-- Worker deployed to AWS
-- Production monitoring working
+- Worker service running in target environment (non-Lambda)
+- Operational monitoring working
 - Documentation updated
 
-**Commit:** `feat: complete worker integration and deployment`
+**Commit:** `feat: complete worker integration and runtime rollout`
 
 ---
 
@@ -411,7 +420,8 @@ By end of sprint, you should have:
 - [ ] `src/services/delivery.rs` - HTTP delivery
 - [ ] `src/services/signature.rs` - HMAC generation
 - [ ] `src/services/mod.rs` - Service exports
-- [ ] `tests/end_to_end_test.sh` - Integration tests
+- [ ] `worker/tests/end_to_end_test.sh` - Contract integration helper
+- [ ] `scripts/e2e_ingestion_worker.sh` - Full ingestion->worker e2e
 - [ ] `tests/test_dynamodb.sh` - DynamoDB tests
 - [ ] `docs/runbook.md` - Operational guide
 - [ ] `docs/troubleshooting.md` - Common issues
@@ -422,23 +432,23 @@ By end of sprint, you should have:
 ## Emergency Procedures
 
 ### Worker Stopped Processing
-1. Check CloudWatch logs for errors: `sam logs --name WorkerFunction --tail`
+1. Check worker service logs for errors (`journalctl`, container logs, or process logs)
 2. Verify SQS queue has messages: `aws sqs get-queue-attributes --queue-url $QUEUE_URL`
-3. Check IAM permissions on Lambda role
-4. Restart Lambda: Redeploy with `sam deploy`
+3. Check IAM permissions for the worker runtime role/user
+4. Restart worker process or service (systemd/ECS task rollout)
 
 ### High Failure Rate
 1. Check customer endpoint health: `curl -X POST $CUSTOMER_URL`
 2. Review delivery attempt logs in DynamoDB
 3. Verify HMAC signatures are correct
-4. Check network connectivity from Lambda to customer endpoints
+4. Check network connectivity from worker runtime to customer endpoints
 5. Temporarily disable failing endpoint configs
 
 ### Queue Backing Up
-1. Check worker Lambda concurrency: May need to increase
-2. Monitor Lambda errors: Fix any code issues
+1. Check worker replica/process count: scale out if needed
+2. Monitor worker errors: Fix any code issues
 3. Check DynamoDB throttling: May need provisioned capacity
-4. Consider temporarily scaling up Lambda memory/timeout
+4. Consider increasing worker CPU/memory limits in runtime platform
 
 ---
 
@@ -449,7 +459,6 @@ By end of sprint, you should have:
 **AWS Documentation:**
 - [DynamoDB Developer Guide](https://docs.aws.amazon.com/dynamodb/)
 - [SQS Developer Guide](https://docs.aws.amazon.com/sqs/)
-- [Lambda Developer Guide](https://docs.aws.amazon.com/lambda/)
 
 **Project Dictionary:** See `PROJECT_DICTIONARY.md` for complete schemas, architecture, and patterns
 

--- a/docs/PROJECT_DICTIONARY.md
+++ b/docs/PROJECT_DICTIONARY.md
@@ -848,23 +848,14 @@ See full template in Infrastructure section above.
 ### Build and Deploy
 
 ```bash
-# Build Rust Lambda functions
-cd ingestion
-cargo lambda build --release --arm64
-cd ../worker
-cargo lambda build --release --arm64
-cd ..
-
-# Deploy with SAM
+# Build and deploy ingestion/shared infra with SAM
 sam build
-sam deploy --guided
+sam deploy --resolve-s3
 
-# Follow prompts:
-# - Stack Name: webhook-relay-mvp
-# - AWS Region: us-east-1
-# - Confirm changes: Y
-# - Allow SAM CLI IAM role creation: Y
-# - Save arguments to config: Y
+# For ECS worker-enabled deploys (local/dev):
+# 1) set account-specific values in samconfig.local.toml
+# 2) deploy with helper script
+./scripts/deploy_dev.sh
 ```
 
 ### Environment Variables
@@ -873,11 +864,11 @@ Create `.env` file for local testing:
 
 ```bash
 # .env
-AWS_REGION=us-east-1
-EVENTS_TABLE=webhook_events
-IDEMPOTENCY_TABLE=webhook_idempotency
-CONFIGS_TABLE=webhook_configs
-DELIVERY_QUEUE_URL=https://sqs.us-east-1.amazonaws.com/123456789/webhook-delivery
+AWS_REGION=us-west-2
+EVENTS_TABLE=webhook_events_dev
+IDEMPOTENCY_TABLE=webhook_idempotency_dev
+CONFIGS_TABLE=webhook_configs_dev
+QUEUE_URL=https://sqs.us-west-2.amazonaws.com/<account-id>/webhook_delivery_dev
 LOG_LEVEL=info
 ```
 
@@ -978,17 +969,17 @@ aws dynamodb get-item \
 ```bash
 # Send test message
 aws sqs send-message \
-  --queue-url https://sqs.us-east-1.amazonaws.com/123/webhook-delivery \
+  --queue-url https://sqs.us-west-2.amazonaws.com/<account-id>/webhook_delivery_dev \
   --message-body "evt_test123"
 
 # Check queue depth
 aws sqs get-queue-attributes \
-  --queue-url https://sqs.us-east-1.amazonaws.com/123/webhook-delivery \
+  --queue-url https://sqs.us-west-2.amazonaws.com/<account-id>/webhook_delivery_dev \
   --attribute-names ApproximateNumberOfMessages
 
 # Purge queue (testing only!)
 aws sqs purge-queue \
-  --queue-url https://sqs.us-east-1.amazonaws.com/123/webhook-delivery
+  --queue-url https://sqs.us-west-2.amazonaws.com/<account-id>/webhook_delivery_dev
 ```
 
 ### Logs
@@ -998,7 +989,7 @@ aws sqs purge-queue \
 sam logs --stack-name webhook-relay-mvp --name IngestionFunction --tail
 
 # Tail worker logs
-sam logs --stack-name webhook-relay-mvp --name WorkerFunction --tail
+journalctl -u webhook-worker -f
 
 # Query logs
 aws logs filter-log-events \

--- a/docs/WORKER_RUNTIME.md
+++ b/docs/WORKER_RUNTIME.md
@@ -1,0 +1,163 @@
+# Worker Runtime Guide (Non-Lambda)
+
+## Decision
+
+The delivery worker is currently designed as a long-running SQS poller (`run()` + long poll loop), so it should run on non-Lambda compute for MVP.
+
+Valid runtime options:
+- ECS/Fargate (recommended managed option for MVP)
+- EC2 + `systemd`
+- Kubernetes
+- Local process for dev/testing
+
+## Required Environment Variables
+
+- `AWS_REGION`
+- `QUEUE_URL` (or `WEBHOOK_QUEUE_URL`)
+- `EVENTS_TABLE` (or `WEBHOOK_EVENTS_TABLE`)
+- `CONFIGS_TABLE` (or `WEBHOOK_CONFIGS_TABLE`)
+
+Optional for e2e testing:
+- `DELIVERY_URL`
+- `SKIP_DELIVERY=false`
+
+## Build and Run
+
+Build:
+
+```bash
+cargo build --release -p worker --bin worker
+```
+
+Run:
+
+```bash
+RUST_LOG=info ./target/release/worker
+```
+
+## ECS/Fargate MVP Rollout
+
+### 1. Build and push image to ECR
+
+```bash
+export AWS_REGION=us-west-2
+export AWS_ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
+export ECR_REPO=hooray-relay-worker
+export IMAGE_TAG="$(git rev-parse --short HEAD)"
+
+aws ecr describe-repositories --repository-names "$ECR_REPO" --region "$AWS_REGION" >/dev/null 2>&1 || \
+aws ecr create-repository --repository-name "$ECR_REPO" --region "$AWS_REGION"
+
+aws ecr get-login-password --region "$AWS_REGION" | \
+docker login --username AWS --password-stdin "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
+
+docker build -f worker/Dockerfile -t "$ECR_REPO:$IMAGE_TAG" .
+docker tag "$ECR_REPO:$IMAGE_TAG" "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${ECR_REPO}:$IMAGE_TAG"
+docker push "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${ECR_REPO}:$IMAGE_TAG"
+```
+
+### 2. Create ECS task role permissions
+
+Worker task role requires:
+- `sqs:ReceiveMessage`, `sqs:DeleteMessage`, `sqs:ChangeMessageVisibility`, `sqs:GetQueueAttributes` on delivery queue
+- `dynamodb:GetItem`, `dynamodb:PutItem`, `dynamodb:UpdateItem` on events/configs tables
+- `logs:CreateLogStream`, `logs:PutLogEvents` for container logs (if needed by your log driver setup)
+
+### 3. Run as ECS service
+
+- Launch type: Fargate
+- Desired count: `1` for MVP
+- Networking: private subnets + NAT (or equivalent outbound internet path)
+- CPU/Memory start point: `0.25 vCPU / 512 MiB`
+- Container env vars: `AWS_REGION`, `QUEUE_URL`, `EVENTS_TABLE`, `CONFIGS_TABLE`
+- Autoscaling target: scale out on SQS queue depth
+- Use helper artifacts in `infra/ecs/`:
+  - `infra/ecs/worker-task-policy.template.json`
+  - `infra/ecs/task-definition.template.json`
+  - `infra/ecs/deploy_worker_service.sh`
+
+## Full Integration E2E
+
+Preferred one-command full integration flow:
+
+```bash
+./scripts/e2e_ingestion_worker.sh
+```
+
+Expected success signals:
+- Delivery attempt row exists: `pk=EVENT#<event_id>, sk=ATTEMPT#1`
+- Event status transitions to `delivered` (or expected failure state)
+- Main queue depth does not grow
+- DLQ depth does not increase for happy-path runs
+
+Contract-only fallback (seed + enqueue + worker assertions helper):
+
+```bash
+SKIP_DELIVERY=false ./worker/tests/end_to_end_test.sh
+```
+
+### Full API -> Queue -> Worker -> DynamoDB E2E (validated on February 26, 2026)
+
+```bash
+REGION=us-west-2
+PROFILE=hooray-dev
+STACK=hooray-dev
+
+API_URL=$(aws cloudformation describe-stacks \
+  --stack-name "$STACK" --region "$REGION" --profile "$PROFILE" \
+  --query "Stacks[0].Outputs[?OutputKey=='IngestionApiUrl'].OutputValue" --output text)
+
+EVENTS_TABLE=$(aws cloudformation describe-stacks \
+  --stack-name "$STACK" --region "$REGION" --profile "$PROFILE" \
+  --query "Stacks[0].Outputs[?OutputKey=='EventsTableName'].OutputValue" --output text)
+
+TS=$(date +%s)
+RAND=$(date +%s%N | tail -c 7)
+CUSTOMER_ID="cust_e2e_${TS}_${RAND}"
+IDEMPOTENCY_KEY="req_e2e_${TS}_${RAND}"
+
+curl -sS -X POST "${API_URL}webhooks/configs" \
+  -H 'content-type: application/json' \
+  -d "{\"customer_id\":\"${CUSTOMER_ID}\",\"url\":\"https://httpbin.org/post\",\"secret\":\"whsec_e2e_test\"}"
+
+RESP=$(curl -sS -X POST "${API_URL}webhooks/receive" \
+  -H 'content-type: application/json' \
+  -d "{\"idempotency_key\":\"${IDEMPOTENCY_KEY}\",\"customer_id\":\"${CUSTOMER_ID}\",\"data\":{\"hello\":\"world\"}}")
+
+EVENT_ID=$(echo "$RESP" | jq -r '.event_id')
+EVENT_PK="EVENT#${EVENT_ID}"
+```
+
+Poll for worker result:
+
+```bash
+aws dynamodb get-item \
+  --region "$REGION" --profile "$PROFILE" --table-name "$EVENTS_TABLE" \
+  --key "{\"pk\":{\"S\":\"${EVENT_PK}\"},\"sk\":{\"S\":\"ATTEMPT#1\"}}" \
+  --query 'Item.pk.S' --output text
+
+aws dynamodb get-item \
+  --region "$REGION" --profile "$PROFILE" --table-name "$EVENTS_TABLE" \
+  --key "{\"pk\":{\"S\":\"${EVENT_PK}\"},\"sk\":{\"S\":\"v0\"}}" \
+  --query 'Item.status.S' --output text
+```
+
+Expected values:
+- Attempt item query returns `EVENT#<event_id>`
+- Status query returns `delivered`
+
+## Operational Checks
+
+- Service logs: verify message processing and delivery result logging.
+- SQS metrics:
+  - `ApproximateNumberOfMessagesVisible`
+  - `ApproximateNumberOfMessagesNotVisible`
+- DLQ metric:
+  - `ApproximateNumberOfMessagesVisible` should remain stable on happy path.
+- ECS health:
+  - task count remains at desired
+  - no frequent task restarts
+
+## Future Migration Note
+
+If moving to SQS-triggered Lambda later, refactor worker from infinite loop to per-batch/per-message Lambda handler first. Keep this runtime until that refactor is complete.

--- a/samconfig.local.toml.example
+++ b/samconfig.local.toml.example
@@ -1,0 +1,14 @@
+version = 0.1
+
+[default.deploy.parameters]
+stack_name = "hooray-dev"
+region = "us-west-2"
+profile = "hooray-dev"
+confirm_changeset = true
+capabilities = "CAPABILITY_IAM CAPABILITY_NAMED_IAM"
+disable_rollback = false
+parameter_overrides = "Environment=dev SqsVisibilityTimeoutSeconds=60 SqsMaxReceiveCount=4 EnableEcsWorker=true WorkerImageUri=<ACCOUNT_ID>.dkr.ecr.us-west-2.amazonaws.com/hooray-relay-worker-dev:<IMAGE_TAG> WorkerDesiredCount=1 WorkerCpu=256 WorkerMemory=512 WorkerAssignPublicIp=ENABLED EcsSubnetIds=<SUBNET_ID_1>,<SUBNET_ID_2> EcsSecurityGroupIds=<SECURITY_GROUP_ID>"
+
+# Notes:
+# - WorkerImageUri must reference an image tag that already exists in ECR.
+# - This template expects ECS worker tasks in ARM64 mode (set in template.yaml).

--- a/samconfig.toml
+++ b/samconfig.toml
@@ -5,6 +5,6 @@ stack_name = "hooray-dev"
 region = "us-west-2"
 profile = "hooray-dev"
 confirm_changeset = true
-capabilities = "CAPABILITY_IAM"
+capabilities = "CAPABILITY_IAM CAPABILITY_NAMED_IAM"
 disable_rollback = false
-parameter_overrides = "Environment=dev SqsVisibilityTimeoutSeconds=60 SqsMaxReceiveCount=4"
+parameter_overrides = "Environment=dev SqsVisibilityTimeoutSeconds=60 SqsMaxReceiveCount=4 EnableEcsWorker=false"

--- a/scripts/deploy_dev.sh
+++ b/scripts/deploy_dev.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ! -f samconfig.local.toml ]]; then
+  echo "samconfig.local.toml not found."
+  echo "Create it from samconfig.local.toml.example and fill in your account/image/subnet/security group values."
+  exit 1
+fi
+
+# Keep build artifacts aligned with the current template before deploy.
+sam build --cached --parallel
+sam deploy --resolve-s3 --config-file samconfig.local.toml --config-env default

--- a/scripts/e2e_ingestion_worker.sh
+++ b/scripts/e2e_ingestion_worker.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Full integration e2e:
+# Ingestion API -> DynamoDB + SQS -> ECS worker -> DynamoDB delivery state
+#
+# Defaults:
+# - AWS_REGION=us-west-2
+# - AWS_PROFILE=hooray-dev
+# - STACK_NAME=hooray-dev
+#
+# Optional:
+# - DELIVERY_URL=https://httpbin.org/post
+# - DELIVERY_SECRET=whsec_e2e_test
+# - POLL_TIMEOUT_SECS=180
+# - POLL_INTERVAL_SECS=5
+# - EXPECTED_STATUS=delivered
+# - KEEP_TEST_DATA=false
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "ERROR: required command not found: $cmd" >&2
+    exit 1
+  fi
+}
+
+require_cmd aws
+require_cmd curl
+require_cmd jq
+
+AWS_REGION="${AWS_REGION:-us-west-2}"
+AWS_PROFILE="${AWS_PROFILE:-hooray-dev}"
+STACK_NAME="${STACK_NAME:-hooray-dev}"
+
+DELIVERY_URL="${DELIVERY_URL:-https://httpbin.org/post}"
+DELIVERY_SECRET="${DELIVERY_SECRET:-whsec_e2e_test}"
+POLL_TIMEOUT_SECS="${POLL_TIMEOUT_SECS:-180}"
+POLL_INTERVAL_SECS="${POLL_INTERVAL_SECS:-5}"
+EXPECTED_STATUS="${EXPECTED_STATUS:-delivered}"
+KEEP_TEST_DATA="${KEEP_TEST_DATA:-false}"
+
+STACK_OUTPUTS_JSON="$(aws cloudformation describe-stacks \
+  --stack-name "$STACK_NAME" \
+  --region "$AWS_REGION" \
+  --profile "$AWS_PROFILE" \
+  --query "Stacks[0].Outputs" \
+  --output json)"
+
+API_URL="$(echo "$STACK_OUTPUTS_JSON" | jq -r '.[] | select(.OutputKey=="IngestionApiUrl") | .OutputValue')"
+EVENTS_TABLE="$(echo "$STACK_OUTPUTS_JSON" | jq -r '.[] | select(.OutputKey=="EventsTableName") | .OutputValue')"
+CONFIGS_TABLE="$(echo "$STACK_OUTPUTS_JSON" | jq -r '.[] | select(.OutputKey=="ConfigsTableName") | .OutputValue')"
+IDEMPOTENCY_TABLE="$(echo "$STACK_OUTPUTS_JSON" | jq -r '.[] | select(.OutputKey=="IdempotencyTableName") | .OutputValue')"
+
+if [[ -z "$API_URL" || -z "$EVENTS_TABLE" || -z "$CONFIGS_TABLE" || -z "$IDEMPOTENCY_TABLE" ]]; then
+  echo "ERROR: missing required stack outputs from $STACK_NAME" >&2
+  exit 1
+fi
+
+TS="$(date +%s)"
+RAND="$(date +%s%N | tail -c 7)"
+CUSTOMER_ID="cust_e2e_${TS}_${RAND}"
+IDEMPOTENCY_KEY="req_e2e_${TS}_${RAND}"
+EVENT_ID=""
+
+cleanup() {
+  local exit_code=$?
+  set +e
+
+  if [[ "$KEEP_TEST_DATA" == "true" ]]; then
+    echo "[CLEANUP] KEEP_TEST_DATA=true, skipping delete"
+    return "$exit_code"
+  fi
+
+  if [[ -n "$EVENT_ID" ]]; then
+    local event_pk="EVENT#${EVENT_ID}"
+    aws dynamodb delete-item \
+      --region "$AWS_REGION" \
+      --profile "$AWS_PROFILE" \
+      --table-name "$EVENTS_TABLE" \
+      --key "{\"pk\":{\"S\":\"${event_pk}\"},\"sk\":{\"S\":\"ATTEMPT#1\"}}" >/dev/null 2>&1 || true
+    aws dynamodb delete-item \
+      --region "$AWS_REGION" \
+      --profile "$AWS_PROFILE" \
+      --table-name "$EVENTS_TABLE" \
+      --key "{\"pk\":{\"S\":\"${event_pk}\"},\"sk\":{\"S\":\"v0\"}}" >/dev/null 2>&1 || true
+  fi
+
+  aws dynamodb delete-item \
+    --region "$AWS_REGION" \
+    --profile "$AWS_PROFILE" \
+    --table-name "$CONFIGS_TABLE" \
+    --key "{\"pk\":{\"S\":\"CUSTOMER#${CUSTOMER_ID}\"},\"sk\":{\"S\":\"CONFIG\"}}" >/dev/null 2>&1 || true
+
+  aws dynamodb delete-item \
+    --region "$AWS_REGION" \
+    --profile "$AWS_PROFILE" \
+    --table-name "$IDEMPOTENCY_TABLE" \
+    --key "{\"pk\":{\"S\":\"IDEM#${IDEMPOTENCY_KEY}\"}}" >/dev/null 2>&1 || true
+
+  return "$exit_code"
+}
+
+trap cleanup EXIT INT TERM
+
+echo "[1/5] Creating webhook config via ingestion API"
+CONFIG_CODE="$(curl -sS -o /tmp/e2e_config_resp.json -w "%{http_code}" \
+  -X POST "${API_URL}webhooks/configs" \
+  -H 'content-type: application/json' \
+  -d "{\"customer_id\":\"${CUSTOMER_ID}\",\"url\":\"${DELIVERY_URL}\",\"secret\":\"${DELIVERY_SECRET}\"}")"
+
+if [[ "$CONFIG_CODE" != "201" && "$CONFIG_CODE" != "200" ]]; then
+  echo "ERROR: config API failed with status $CONFIG_CODE"
+  cat /tmp/e2e_config_resp.json
+  exit 1
+fi
+
+echo "[2/5] Sending webhook event via ingestion API"
+RECEIVE_CODE="$(curl -sS -o /tmp/e2e_receive_resp.json -w "%{http_code}" \
+  -X POST "${API_URL}webhooks/receive" \
+  -H 'content-type: application/json' \
+  -d "{\"idempotency_key\":\"${IDEMPOTENCY_KEY}\",\"customer_id\":\"${CUSTOMER_ID}\",\"data\":{\"test\":\"e2e\",\"source\":\"ingestion-worker\"}}")"
+
+if [[ "$RECEIVE_CODE" != "202" && "$RECEIVE_CODE" != "200" ]]; then
+  echo "ERROR: receive API failed with status $RECEIVE_CODE"
+  cat /tmp/e2e_receive_resp.json
+  exit 1
+fi
+
+EVENT_ID="$(jq -r '.event_id' /tmp/e2e_receive_resp.json)"
+if [[ -z "$EVENT_ID" || "$EVENT_ID" == "null" ]]; then
+  echo "ERROR: missing event_id in ingestion response"
+  cat /tmp/e2e_receive_resp.json
+  exit 1
+fi
+EVENT_PK="EVENT#${EVENT_ID}"
+
+echo "[3/5] Polling DynamoDB for ATTEMPT#1 and status=${EXPECTED_STATUS}"
+deadline=$(( $(date +%s) + POLL_TIMEOUT_SECS ))
+attempt_seen=false
+final_status=""
+
+while [[ "$(date +%s)" -lt "$deadline" ]]; do
+  got_attempt_pk="$(aws dynamodb get-item \
+    --region "$AWS_REGION" \
+    --profile "$AWS_PROFILE" \
+    --table-name "$EVENTS_TABLE" \
+    --key "{\"pk\":{\"S\":\"${EVENT_PK}\"},\"sk\":{\"S\":\"ATTEMPT#1\"}}" \
+    --query 'Item.pk.S' \
+    --output text 2>/dev/null || true)"
+
+  final_status="$(aws dynamodb get-item \
+    --region "$AWS_REGION" \
+    --profile "$AWS_PROFILE" \
+    --table-name "$EVENTS_TABLE" \
+    --key "{\"pk\":{\"S\":\"${EVENT_PK}\"},\"sk\":{\"S\":\"v0\"}}" \
+    --query 'Item.status.S' \
+    --output text 2>/dev/null || true)"
+
+  if [[ "$got_attempt_pk" == "$EVENT_PK" ]]; then
+    attempt_seen=true
+  fi
+
+  if [[ "$attempt_seen" == "true" && "$final_status" == "$EXPECTED_STATUS" ]]; then
+    break
+  fi
+  sleep "$POLL_INTERVAL_SECS"
+done
+
+echo "[4/5] Verifying assertions"
+if [[ "$attempt_seen" != "true" ]]; then
+  echo "ERROR: ATTEMPT#1 was not written for EVENT_ID=$EVENT_ID"
+  exit 1
+fi
+if [[ "$final_status" != "$EXPECTED_STATUS" ]]; then
+  echo "ERROR: expected status=$EXPECTED_STATUS, got status=$final_status for EVENT_ID=$EVENT_ID"
+  exit 1
+fi
+
+echo "[5/5] SUCCESS"
+echo "EVENT_ID=$EVENT_ID"
+echo "CUSTOMER_ID=$CUSTOMER_ID"
+echo "FINAL_STATUS=$final_status"


### PR DESCRIPTION
This pull request introduces significant improvements to the deployment process and documentation for the worker service, shifting the architecture from AWS Lambda-based deployment to a long-running containerized worker (ECS/Fargate or similar). It updates deployment scripts, configuration files, and engineering timelines to reflect this new approach, and adds detailed operational and integration guidance.

**Key changes:**

Deployment process and configuration:

* Updated `samconfig.toml` and added `samconfig.local.toml.example` to distinguish between shared (CI-safe) and account-specific deployment settings, including ECS worker parameters and IAM capabilities. [[1]](diffhunk://#diff-eeb7eaf77ca8ad1dfaf438d0e504ca99dca36448af1078b3881b67fb019853c9L8-R10) [[2]](diffhunk://#diff-a15fc482de50614d8d76cb61b507df780e76eb8f93f5f3af324963d7e4cc3de3R1-R14) [[3]](diffhunk://#diff-ea9864292e6e392d0c8edbabfe41014d61d6ebd2e08f34d8ae21bf9d070fb274L23-R23) [[4]](diffhunk://#diff-ea9864292e6e392d0c8edbabfe41014d61d6ebd2e08f34d8ae21bf9d070fb274L33-R44)
* Added `scripts/deploy_dev.sh` helper script to simplify local/dev ECS worker deployments using local config overrides. [[1]](diffhunk://#diff-4ab18f3231486cb44e3e4c8929b0c1184dc9099ac381225f52b86a17ad27151aR1-R12) [[2]](diffhunk://#diff-ea9864292e6e392d0c8edbabfe41014d61d6ebd2e08f34d8ae21bf9d070fb274L155-R236)
* Modified Makefile and build instructions to reflect that the worker is not deployed as a Lambda; instead, it is built and run as a standalone service/container. [[1]](diffhunk://#diff-ea9864292e6e392d0c8edbabfe41014d61d6ebd2e08f34d8ae21bf9d070fb274L51-R69) [[2]](diffhunk://#diff-80ed23398fb7a567da670eee9cdf83f4599b6fe163770547ea33641b9aa409c4L851-R858)

Worker runtime and operational documentation:

* Added `docs/WORKER_RUNTIME.md` with comprehensive instructions for building, deploying, and running the worker as a containerized service (ECS/Fargate recommended), including required environment variables, IAM permissions, and integration test flows.
* Updated `.env` example, SQS, and DynamoDB command examples to use consistent dev environment settings and new variable names (`QUEUE_URL` instead of `DELIVERY_QUEUE_URL`). [[1]](diffhunk://#diff-80ed23398fb7a567da670eee9cdf83f4599b6fe163770547ea33641b9aa409c4L876-R871) [[2]](diffhunk://#diff-80ed23398fb7a567da670eee9cdf83f4599b6fe163770547ea33641b9aa409c4L981-R982) [[3]](diffhunk://#diff-80ed23398fb7a567da670eee9cdf83f4599b6fe163770547ea33641b9aa409c4L1001-R992)

Engineering timelines and handoff:

* Revised both Engineer 1 and Engineer 2 timelines to reflect the new deployment model—removing Lambda deployment steps, adding ECS/container build and rollout steps, and updating integration/e2e test scripts and deliverables. [[1]](diffhunk://#diff-576c585d58dde3a2a1522e2f958af2d85ccb6d9fa4f048a610a2391dfffea07cL21-R21) [[2]](diffhunk://#diff-576c585d58dde3a2a1522e2f958af2d85ccb6d9fa4f048a610a2391dfffea07cL134-R134) [[3]](diffhunk://#diff-22ecc3dbdef666f8f25efce96997f4e2e0139ec2ba129af9e91530de5e1980ddL130-R130) [[4]](diffhunk://#diff-22ecc3dbdef666f8f25efce96997f4e2e0139ec2ba129af9e91530de5e1980ddL172-R215) [[5]](diffhunk://#diff-22ecc3dbdef666f8f25efce96997f4e2e0139ec2ba129af9e91530de5e1980ddL414-R424) [[6]](diffhunk://#diff-22ecc3dbdef666f8f25efce96997f4e2e0139ec2ba129af9e91530de5e1980ddL425-R451) [[7]](diffhunk://#diff-22ecc3dbdef666f8f25efce96997f4e2e0139ec2ba129af9e91530de5e1980ddL452)

These changes modernize the deployment flow, clarify local vs. CI configuration, and provide clear operational guidance for running and monitoring the worker service as a non-Lambda container.