### PR TITLE
chore: align env/build/readme with ECS worker runtime

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -27,11 +27,6 @@ export INGESTION_API_URL=$(aws cloudformation describe-stacks \
   --stack-name "$STACK_NAME" --region "$AWS_REGION" \
   --query "Stacks[0].Outputs[?OutputKey=='IngestionApiUrl'].OutputValue" \
   --output text)
-export WORKER_FN=$(aws cloudformation describe-stack-resources \
-  --stack-name "$STACK_NAME" --region "$AWS_REGION" \
-  --logical-resource-id "WorkerFunction" \
-  --query "StackResources[0].PhysicalResourceId" \
-  --output text)
 
 # Backward-compatible aliases for older scripts
 export WEBHOOK_EVENTS_TABLE="$EVENTS_TABLE"

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,12 @@
-.PHONY: package-ingestion package-worker build-IngestionFunction build-WorkerFunction
+.PHONY: package-ingestion package-worker build-IngestionFunction
 
 package-ingestion:
-	cargo build --locked --release -p ingestion --bin ingestion
+	cargo lambda build --locked --release --arm64 -p ingestion --bin ingestion
 	mkdir -p "$(ARTIFACTS_DIR)"
-	cp "target/release/ingestion" "$(ARTIFACTS_DIR)/bootstrap"
+	cp "target/lambda/ingestion/bootstrap" "$(ARTIFACTS_DIR)/bootstrap"
 	chmod +x "$(ARTIFACTS_DIR)/bootstrap"
 
 package-worker:
 	cargo build --locked --release -p worker --bin worker
-	mkdir -p "$(ARTIFACTS_DIR)"
-	cp "target/release/worker" "$(ARTIFACTS_DIR)/bootstrap"
-	chmod +x "$(ARTIFACTS_DIR)/bootstrap"
 
 build-IngestionFunction: package-ingestion
-
-build-WorkerFunction: package-worker

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # HooRay-Relay
-Production-grade webhook delivery system built with Rust and AWS serverless. Reliable, scalable, and easy to deploy.
+Production-grade webhook delivery system built with Rust and AWS. Reliable, scalable, and easy to deploy.
+
+Current runtime split:
+- Ingestion API runs as Lambda (SAM-managed).
+- Delivery worker runs as a long-running SQS poller (non-Lambda) for MVP.
+- See `docs/WORKER_RUNTIME.md` for worker deployment and e2e steps.
 
 ## Worker Workflow
 


### PR DESCRIPTION

This pull request refactors the build and deployment workflow for the ingestion and worker components, clarifies the runtime environment in documentation, and removes Lambda-specific configuration for the worker. The changes focus on shifting the worker away from AWS Lambda to a long-running process and updating build commands to use the latest recommended tools.

**Build and Deployment Workflow Updates:**

* Updated the `Makefile` to use `cargo lambda build` for the ingestion Lambda, and removed Lambda packaging and build steps for the worker, reflecting its new non-Lambda runtime.

**Configuration Cleanup:**

* Removed the `WORKER_FN` Lambda resource export from `.envrc.example`, since the worker is no longer deployed as a Lambda function.

**Documentation Updates:**

* Clarified in `README.md` that the ingestion API runs as Lambda, while the worker is now a long-running SQS poller, and pointed to `docs/WORKER_RUNTIME.md` for deployment steps.