### PR TITLE
feat(worker): add day6 observability metrics, alarms, and e2e checks

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -27,11 +27,6 @@ export INGESTION_API_URL=$(aws cloudformation describe-stacks \
   --stack-name "$STACK_NAME" --region "$AWS_REGION" \
   --query "Stacks[0].Outputs[?OutputKey=='IngestionApiUrl'].OutputValue" \
   --output text)
-export WORKER_FN=$(aws cloudformation describe-stack-resources \
-  --stack-name "$STACK_NAME" --region "$AWS_REGION" \
-  --logical-resource-id "WorkerFunction" \
-  --query "StackResources[0].PhysicalResourceId" \
-  --output text)
 
 # Backward-compatible aliases for older scripts
 export WEBHOOK_EVENTS_TABLE="$EVENTS_TABLE"

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,12 @@
-.PHONY: package-ingestion package-worker build-IngestionFunction build-WorkerFunction
+.PHONY: package-ingestion package-worker build-IngestionFunction
 
 package-ingestion:
-	cargo build --locked --release -p ingestion --bin ingestion
+	cargo lambda build --locked --release --arm64 -p ingestion --bin ingestion
 	mkdir -p "$(ARTIFACTS_DIR)"
-	cp "target/release/ingestion" "$(ARTIFACTS_DIR)/bootstrap"
+	cp "target/lambda/ingestion/bootstrap" "$(ARTIFACTS_DIR)/bootstrap"
 	chmod +x "$(ARTIFACTS_DIR)/bootstrap"
 
 package-worker:
 	cargo build --locked --release -p worker --bin worker
-	mkdir -p "$(ARTIFACTS_DIR)"
-	cp "target/release/worker" "$(ARTIFACTS_DIR)/bootstrap"
-	chmod +x "$(ARTIFACTS_DIR)/bootstrap"
 
 build-IngestionFunction: package-ingestion
-
-build-WorkerFunction: package-worker

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # HooRay-Relay
-Production-grade webhook delivery system built with Rust and AWS serverless. Reliable, scalable, and easy to deploy.
+Production-grade webhook delivery system built with Rust and AWS. Reliable, scalable, and easy to deploy.
+
+Current runtime split:
+- Ingestion API runs as Lambda (SAM-managed).
+- Delivery worker runs as a long-running SQS poller (non-Lambda) for MVP.
+- See `docs/WORKER_RUNTIME.md` for worker deployment and e2e steps.
 
 ## Worker Workflow
 

--- a/docs/ENGINEER_2_TIMELINE.md
+++ b/docs/ENGINEER_2_TIMELINE.md
@@ -175,7 +175,7 @@
 - [ ] Meet with Engineer 1 for integration sync
 - [ ] Verify SQS message format matches expectations
 - [ ] Confirm DynamoDB schemas are correct
-- [ ] Create `scripts/e2e_ingestion_worker.sh`:
+- [x] Create `scripts/e2e_ingestion_worker.sh`:
   - Create webhook config through ingestion API
   - Submit event through ingestion API
   - Verify worker writes `ATTEMPT#1`
@@ -188,7 +188,7 @@
 - [ ] Prepare runtime environment:
   - Confirm AWS credentials/profile can access SQS + DynamoDB
   - Confirm `QUEUE_URL`, `EVENTS_TABLE`, `CONFIGS_TABLE`, `AWS_REGION`
-- [ ] Build and push worker image:
+- [x] Build and push worker image:
   - Build image from `worker/Dockerfile`
   - Push to ECR
   - Update `WorkerImageUri` tag in `samconfig.local.toml`
@@ -223,26 +223,26 @@
 **Goal:** Add comprehensive monitoring for delivery pipeline
 
 **Tasks:**
-- [ ] Add CloudWatch metrics emission:
+- [x] Add CloudWatch metrics emission:
   - DeliveryAttempts (count)
   - DeliverySuccess (count)
   - DeliveryFailure (count)
   - DeliveryLatency (milliseconds)
   - HTTPStatusCode (by status)
-- [ ] Create CloudWatch dashboard for worker:
+- [x] Create CloudWatch dashboard for worker:
   - Success/failure rates
   - Latency percentiles
   - Error breakdown
   - Queue depth over time
-- [ ] Set up alarms:
+- [x] Set up alarms:
   - High failure rate (>10%)
   - High latency (p95 >5s)
   - DLQ messages present
 - [ ] Test alarms trigger correctly
 
 **Deliverables:**
-- Metrics emitting properly
-- Dashboard operational
+- [x] Metrics emitting properly
+- [x] Dashboard operational
 - Alarms configured and tested
 
 **Commit:** `feat: add CloudWatch monitoring for delivery worker`
@@ -414,15 +414,15 @@ By end of Week 2, verify:
 ## Key Files Checklist
 
 By end of sprint, you should have:
-- [ ] `src/main.rs` - Worker main loop
+- [x] `src/main.rs` - Worker main loop
 - [ ] `src/models.rs` - Data structures
-- [ ] `src/services/dynamodb.rs` - DynamoDB operations
-- [ ] `src/services/delivery.rs` - HTTP delivery
-- [ ] `src/services/signature.rs` - HMAC generation
-- [ ] `src/services/mod.rs` - Service exports
-- [ ] `worker/tests/end_to_end_test.sh` - Contract integration helper
-- [ ] `scripts/e2e_ingestion_worker.sh` - Full ingestion->worker e2e
-- [ ] `tests/test_dynamodb.sh` - DynamoDB tests
+- [x] `src/services/dynamodb.rs` - DynamoDB operations
+- [x] `src/services/delivery.rs` - HTTP delivery
+- [x] `src/services/signature.rs` - HMAC generation
+- [x] `src/services/mod.rs` - Service exports
+- [x] `worker/tests/end_to_end_test.sh` - Contract integration helper
+- [x] `scripts/e2e_ingestion_worker.sh` - Full ingestion->worker e2e
+- [x] `tests/test_dynamodb.sh` - DynamoDB tests
 - [ ] `docs/runbook.md` - Operational guide
 - [ ] `docs/troubleshooting.md` - Common issues
 - [ ] `README.md` - Worker overview

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,29 @@
+# Worker Monitoring Artifacts
+
+These files support Day 6 monitoring rollout for the delivery worker.
+
+## Apply Dashboard
+
+```bash
+aws cloudwatch put-dashboard \
+  --dashboard-name hooray-relay-worker-dev \
+  --dashboard-body file://monitoring/worker-dashboard.json \
+  --region us-west-2 \
+  --profile hooray-dev
+```
+
+## Apply Alarms
+
+```bash
+aws cloudwatch put-metric-alarm \
+  --cli-input-json file://monitoring/alarms/worker-failure-rate.json \
+  --region us-west-2 \
+  --profile hooray-dev
+
+aws cloudwatch put-metric-alarm \
+  --cli-input-json file://monitoring/alarms/worker-latency-p95.json \
+  --region us-west-2 \
+  --profile hooray-dev
+```
+
+`DLQDepthAlarm` is provisioned via `template.yaml` and should remain enabled.

--- a/monitoring/alarms/worker-failure-rate.json
+++ b/monitoring/alarms/worker-failure-rate.json
@@ -1,0 +1,48 @@
+{
+  "AlarmName": "hooray-worker-failure-rate-dev",
+  "AlarmDescription": "Worker failure rate > 10% over 5 minutes",
+  "ComparisonOperator": "GreaterThanThreshold",
+  "EvaluationPeriods": 1,
+  "Threshold": 10,
+  "TreatMissingData": "notBreaching",
+  "Metrics": [
+    {
+      "Id": "failures",
+      "ReturnData": false,
+      "MetricStat": {
+        "Metric": {
+          "Namespace": "HoorayRelay/Worker",
+          "MetricName": "webhook.delivery.failure",
+          "Dimensions": [
+            { "Name": "environment", "Value": "dev" },
+            { "Name": "queue_name", "Value": "webhook_delivery_dev" }
+          ]
+        },
+        "Period": 300,
+        "Stat": "Sum"
+      }
+    },
+    {
+      "Id": "successes",
+      "ReturnData": false,
+      "MetricStat": {
+        "Metric": {
+          "Namespace": "HoorayRelay/Worker",
+          "MetricName": "webhook.delivery.success",
+          "Dimensions": [
+            { "Name": "environment", "Value": "dev" },
+            { "Name": "queue_name", "Value": "webhook_delivery_dev" }
+          ]
+        },
+        "Period": 300,
+        "Stat": "Sum"
+      }
+    },
+    {
+      "Id": "failureRate",
+      "Expression": "IF((failures + successes) > 0, 100 * failures / (failures + successes), 0)",
+      "Label": "FailureRatePercent",
+      "ReturnData": true
+    }
+  ]
+}

--- a/monitoring/alarms/worker-latency-p95.json
+++ b/monitoring/alarms/worker-latency-p95.json
@@ -1,0 +1,16 @@
+{
+  "AlarmName": "hooray-worker-latency-p95-dev",
+  "AlarmDescription": "Worker delivery latency p95 > 5000ms over 5 minutes",
+  "ComparisonOperator": "GreaterThanThreshold",
+  "EvaluationPeriods": 1,
+  "Threshold": 5000,
+  "TreatMissingData": "notBreaching",
+  "MetricName": "webhook.delivery.latency_ms",
+  "Namespace": "HoorayRelay/Worker",
+  "Dimensions": [
+    { "Name": "environment", "Value": "dev" },
+    { "Name": "queue_name", "Value": "webhook_delivery_dev" }
+  ],
+  "Period": 300,
+  "ExtendedStatistic": "p95"
+}

--- a/monitoring/worker-dashboard.json
+++ b/monitoring/worker-dashboard.json
@@ -1,0 +1,75 @@
+{
+  "widgets": [
+    {
+      "type": "metric",
+      "x": 0,
+      "y": 0,
+      "width": 12,
+      "height": 6,
+      "properties": {
+        "title": "Delivery Success vs Failure (5m Sum)",
+        "view": "timeSeries",
+        "stacked": false,
+        "region": "us-west-2",
+        "period": 300,
+        "stat": "Sum",
+        "metrics": [
+          ["HoorayRelay/Worker", "webhook.delivery.success", "environment", "dev", "queue_name", "webhook_delivery_dev"],
+          [".", "webhook.delivery.failure", ".", ".", ".", "."]
+        ]
+      }
+    },
+    {
+      "type": "metric",
+      "x": 12,
+      "y": 0,
+      "width": 12,
+      "height": 6,
+      "properties": {
+        "title": "Delivery Latency p95 (ms)",
+        "view": "timeSeries",
+        "region": "us-west-2",
+        "period": 300,
+        "stat": "p95",
+        "metrics": [
+          ["HoorayRelay/Worker", "webhook.delivery.latency_ms", "environment", "dev", "queue_name", "webhook_delivery_dev"]
+        ]
+      }
+    },
+    {
+      "type": "metric",
+      "x": 0,
+      "y": 6,
+      "width": 12,
+      "height": 6,
+      "properties": {
+        "title": "Worker Queue Depth (Custom Metric)",
+        "view": "timeSeries",
+        "region": "us-west-2",
+        "period": 60,
+        "stat": "Maximum",
+        "metrics": [
+          ["HoorayRelay/Worker", "webhook.queue.depth", "environment", "dev", "queue_name", "webhook_delivery_dev"]
+        ]
+      }
+    },
+    {
+      "type": "metric",
+      "x": 12,
+      "y": 6,
+      "width": 12,
+      "height": 6,
+      "properties": {
+        "title": "SQS Visible vs In Flight",
+        "view": "timeSeries",
+        "region": "us-west-2",
+        "period": 60,
+        "stat": "Average",
+        "metrics": [
+          ["AWS/SQS", "ApproximateNumberOfMessagesVisible", "QueueName", "webhook_delivery_dev"],
+          [".", "ApproximateNumberOfMessagesNotVisible", ".", "."]
+        ]
+      }
+    }
+  ]
+}

--- a/scripts/e2e_day6_observability.sh
+++ b/scripts/e2e_day6_observability.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Day 6 observability verification:
+# 1) Send one successful delivery event and one exhausted-failure event (HTTP 404)
+# 2) Verify worker delivery-attempt JSON logs contain required fields
+# 3) Verify custom CloudWatch metrics are visible
+# 4) Verify alarms exist (and optionally apply dashboard/alarms first)
+#
+# Defaults:
+# - AWS_REGION=us-west-2
+# - AWS_PROFILE=hooray-dev
+# - STACK_NAME=hooray-dev
+# - ENVIRONMENT=dev
+# - METRIC_NAMESPACE=HoorayRelay/Worker
+# - LOG_GROUP_NAME=/ecs/hooray-relay-worker-dev
+# - METRIC_WAIT_SECS=180
+# - METRIC_POLL_INTERVAL_SECS=10
+# - LOG_WAIT_SECS=180
+# - LOG_POLL_INTERVAL_SECS=10
+# - APPLY_MONITORING=false
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "ERROR: required command not found: $cmd" >&2
+    exit 1
+  fi
+}
+
+require_cmd aws
+require_cmd jq
+require_cmd bash
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+
+AWS_REGION="${AWS_REGION:-us-west-2}"
+AWS_PROFILE="${AWS_PROFILE:-hooray-dev}"
+STACK_NAME="${STACK_NAME:-hooray-dev}"
+ENVIRONMENT="${ENVIRONMENT:-dev}"
+METRIC_NAMESPACE="${METRIC_NAMESPACE:-HoorayRelay/Worker}"
+LOG_GROUP_NAME="${LOG_GROUP_NAME:-/ecs/hooray-relay-worker-${ENVIRONMENT}}"
+METRIC_WAIT_SECS="${METRIC_WAIT_SECS:-180}"
+METRIC_POLL_INTERVAL_SECS="${METRIC_POLL_INTERVAL_SECS:-10}"
+LOG_WAIT_SECS="${LOG_WAIT_SECS:-180}"
+LOG_POLL_INTERVAL_SECS="${LOG_POLL_INTERVAL_SECS:-10}"
+APPLY_MONITORING="${APPLY_MONITORING:-false}"
+
+FAILURE_RATE_ALARM_NAME="${FAILURE_RATE_ALARM_NAME:-hooray-worker-failure-rate-${ENVIRONMENT}}"
+LATENCY_P95_ALARM_NAME="${LATENCY_P95_ALARM_NAME:-hooray-worker-latency-p95-${ENVIRONMENT}}"
+DLQ_ALARM_NAME="${DLQ_ALARM_NAME:-hooray-relay-dlq-depth-${ENVIRONMENT}}"
+
+if [[ "$APPLY_MONITORING" == "true" ]]; then
+  echo "[setup] Applying dashboard + alarms from monitoring/ artifacts"
+  aws cloudwatch put-dashboard \
+    --dashboard-name "hooray-relay-worker-${ENVIRONMENT}" \
+    --dashboard-body "file://${REPO_ROOT}/monitoring/worker-dashboard.json" \
+    --region "$AWS_REGION" \
+    --profile "$AWS_PROFILE" >/dev/null
+
+  aws cloudwatch put-metric-alarm \
+    --cli-input-json "file://${REPO_ROOT}/monitoring/alarms/worker-failure-rate.json" \
+    --region "$AWS_REGION" \
+    --profile "$AWS_PROFILE" >/dev/null
+
+  aws cloudwatch put-metric-alarm \
+    --cli-input-json "file://${REPO_ROOT}/monitoring/alarms/worker-latency-p95.json" \
+    --region "$AWS_REGION" \
+    --profile "$AWS_PROFILE" >/dev/null
+fi
+
+STACK_OUTPUTS_JSON="$(aws cloudformation describe-stacks \
+  --stack-name "$STACK_NAME" \
+  --region "$AWS_REGION" \
+  --profile "$AWS_PROFILE" \
+  --query "Stacks[0].Outputs" \
+  --output json)"
+
+QUEUE_URL="$(echo "$STACK_OUTPUTS_JSON" | jq -r '.[] | select(.OutputKey=="QueueUrl") | .OutputValue')"
+if [[ -z "$QUEUE_URL" || "$QUEUE_URL" == "null" ]]; then
+  echo "ERROR: QueueUrl output missing from stack $STACK_NAME" >&2
+  exit 1
+fi
+QUEUE_NAME="${QUEUE_URL##*/}"
+
+echo "[1/5] Generating success + failure traffic"
+SUCCESS_OUT="$(mktemp)"
+FAILURE_OUT="$(mktemp)"
+
+(
+  cd "$REPO_ROOT"
+  DELIVERY_URL="https://httpbin.org/post" \
+  EXPECTED_STATUS="delivered" \
+  KEEP_TEST_DATA="false" \
+  AWS_REGION="$AWS_REGION" \
+  AWS_PROFILE="$AWS_PROFILE" \
+  STACK_NAME="$STACK_NAME" \
+  ./scripts/e2e_ingestion_worker.sh | tee "$SUCCESS_OUT"
+)
+
+(
+  cd "$REPO_ROOT"
+  DELIVERY_URL="https://httpbin.org/status/404" \
+  EXPECTED_STATUS="failed" \
+  KEEP_TEST_DATA="false" \
+  AWS_REGION="$AWS_REGION" \
+  AWS_PROFILE="$AWS_PROFILE" \
+  STACK_NAME="$STACK_NAME" \
+  ./scripts/e2e_ingestion_worker.sh | tee "$FAILURE_OUT"
+)
+
+SUCCESS_EVENT_ID="$(grep '^EVENT_ID=' "$SUCCESS_OUT" | tail -n1 | cut -d= -f2-)"
+FAILURE_EVENT_ID="$(grep '^EVENT_ID=' "$FAILURE_OUT" | tail -n1 | cut -d= -f2-)"
+
+if [[ -z "$SUCCESS_EVENT_ID" || -z "$FAILURE_EVENT_ID" ]]; then
+  echo "ERROR: unable to parse EVENT_ID values from e2e outputs" >&2
+  exit 1
+fi
+
+echo "[2/5] Verifying custom metric names are present in CloudWatch"
+metric_names=(
+  "webhook.delivery.success"
+  "webhook.delivery.failure"
+  "webhook.delivery.latency_ms"
+  "webhook.queue.depth"
+)
+
+metric_namespaces=("$METRIC_NAMESPACE")
+if [[ "$METRIC_NAMESPACE" != "HooRayRelay/Worker" ]]; then
+  metric_namespaces+=("HooRayRelay/Worker")
+fi
+
+for metric in "${metric_names[@]}"; do
+  found="false"
+  matched_namespace=""
+  deadline=$(( $(date +%s) + METRIC_WAIT_SECS ))
+  while [[ "$(date +%s)" -lt "$deadline" ]]; do
+    for ns in "${metric_namespaces[@]}"; do
+      start_time="$(date -u -v-30M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d '30 minutes ago' +%Y-%m-%dT%H:%M:%SZ)"
+      end_time="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+      datapoints="$(aws cloudwatch get-metric-statistics \
+        --namespace "$ns" \
+        --metric-name "$metric" \
+        --dimensions "Name=environment,Value=${ENVIRONMENT}" "Name=queue_name,Value=${QUEUE_NAME}" \
+        --start-time "$start_time" \
+        --end-time "$end_time" \
+        --period 60 \
+        --statistics Sum \
+        --region "$AWS_REGION" \
+        --profile "$AWS_PROFILE" \
+        --query "length(Datapoints)" \
+        --output text 2>/dev/null || true)"
+
+      if [[ "$datapoints" =~ ^[0-9]+$ ]] && (( datapoints > 0 )); then
+        found="true"
+        matched_namespace="$ns"
+        break
+      fi
+    done
+    [[ "$found" == "true" ]] && break
+    sleep "$METRIC_POLL_INTERVAL_SECS"
+  done
+
+  if [[ "$found" != "true" ]]; then
+    echo "  - metric datapoint not visible yet for $metric; checking EMF logs directly"
+    start_time_ms="$(( ( $(date +%s) - 1800 ) * 1000 ))"
+    emf_count="$(aws logs filter-log-events \
+      --log-group-name "$LOG_GROUP_NAME" \
+      --start-time "$start_time_ms" \
+      --filter-pattern "\"_aws\" \"$metric\" \"$QUEUE_NAME\" \"$ENVIRONMENT\"" \
+      --region "$AWS_REGION" \
+      --profile "$AWS_PROFILE" \
+      --query "length(events)" \
+      --output text 2>/dev/null || true)"
+
+    if [[ "$emf_count" =~ ^[0-9]+$ ]] && (( emf_count > 0 )); then
+      echo "  - EMF payload found in logs for $metric (CloudWatch metric ingestion may still be delayed)"
+      continue
+    fi
+
+    echo "ERROR: metric not visible and no EMF log payload found: $metric (namespaces=${metric_namespaces[*]}, environment=$ENVIRONMENT, queue_name=$QUEUE_NAME)" >&2
+    echo "HINT: ensure latest worker image is deployed and log group is $LOG_GROUP_NAME" >&2
+    exit 1
+  fi
+  echo "  - metric visible: $metric (namespace=$matched_namespace)"
+done
+
+echo "[3/5] Verifying delivery-attempt log fields for both events"
+START_TIME_MS="$(( ( $(date +%s) - 1800 ) * 1000 ))"
+for event_id in "$SUCCESS_EVENT_ID" "$FAILURE_EVENT_ID"; do
+  message=""
+  deadline=$(( $(date +%s) + LOG_WAIT_SECS ))
+  while [[ "$(date +%s)" -lt "$deadline" ]]; do
+    events_json="$(aws logs filter-log-events \
+      --log-group-name "$LOG_GROUP_NAME" \
+      --start-time "$START_TIME_MS" \
+      --filter-pattern "{ $.event_type = \"delivery_attempt\" && $.event_id = \"${event_id}\" }" \
+      --region "$AWS_REGION" \
+      --profile "$AWS_PROFILE" \
+      --output json)"
+    message="$(echo "$events_json" | jq -r '.events[0].message // empty')"
+    [[ -n "$message" ]] && break
+    sleep "$LOG_POLL_INTERVAL_SECS"
+  done
+
+  if [[ -z "$message" ]]; then
+    echo "ERROR: no delivery_attempt log found for event_id=$event_id in $LOG_GROUP_NAME after ${LOG_WAIT_SECS}s" >&2
+    exit 1
+  fi
+
+  echo "$message" | jq -e '
+    has("event_id") and
+    has("customer_id") and
+    has("attempt_number") and
+    has("result") and
+    has("http_status") and
+    has("latency_ms") and
+    has("error")
+  ' >/dev/null || {
+    echo "ERROR: delivery_attempt log missing required fields for event_id=$event_id" >&2
+    echo "Log: $message" >&2
+    exit 1
+  }
+
+  echo "  - log fields verified for event_id=$event_id"
+done
+
+echo "[4/5] Verifying alarm existence and current state"
+alarms_json="$(aws cloudwatch describe-alarms \
+  --alarm-names "$FAILURE_RATE_ALARM_NAME" "$LATENCY_P95_ALARM_NAME" "$DLQ_ALARM_NAME" \
+  --region "$AWS_REGION" \
+  --profile "$AWS_PROFILE" \
+  --output json)"
+
+for alarm in "$FAILURE_RATE_ALARM_NAME" "$LATENCY_P95_ALARM_NAME" "$DLQ_ALARM_NAME"; do
+  state="$(echo "$alarms_json" | jq -r --arg a "$alarm" '.MetricAlarms[] | select(.AlarmName==$a) | .StateValue' | head -n1)"
+  if [[ -z "$state" || "$state" == "null" ]]; then
+    echo "ERROR: alarm not found: $alarm (set APPLY_MONITORING=true to create missing Day 6 alarms)" >&2
+    exit 1
+  fi
+  echo "  - alarm present: $alarm (state=$state)"
+done
+
+echo "[5/5] SUCCESS"
+echo "SUCCESS_EVENT_ID=$SUCCESS_EVENT_ID"
+echo "FAILURE_EVENT_ID=$FAILURE_EVENT_ID"
+echo "QUEUE_NAME=$QUEUE_NAME"
+
+echo "Done. Observability signals validated for Day 6 scope."

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -1,7 +1,9 @@
 pub mod model;
+pub mod observability;
 pub mod services;
 use aws_sdk_dynamodb::Client as DynamoDbClient;
 use aws_sdk_sqs as sqs;
+use observability::Observability;
 use services::{delivery::DeliveryService, dynamodb::DynamoDbService};
 use sqs::types::Message;
 use std::{env, time::Duration};
@@ -20,6 +22,7 @@ struct Worker {
     sqs_client: sqs::Client,
     queue_url: String,
     dynamodb_service: DynamoDbService,
+    observability: Observability,
 }
 
 impl Worker {
@@ -50,6 +53,7 @@ impl Worker {
         Ok(Worker {
             delivery_service: DeliveryService::new(),
             sqs_client: sqs::Client::new(&config),
+            observability: Observability::new(&queue_url),
             queue_url,
             dynamodb_service: DynamoDbService::new(
                 DynamoDbClient::new(&config),
@@ -71,6 +75,8 @@ impl Worker {
 
     async fn poll_and_process(&self) -> Result<(), WorkerError> {
         info!("polling SQS");
+        self.emit_queue_depth_metric().await;
+
         let response = self
             .sqs_client
             .receive_message()
@@ -96,6 +102,7 @@ impl Worker {
                 error!(error = %err, "failed to process message");
             }
         }
+        self.emit_queue_depth_metric().await;
 
         Ok(())
     }
@@ -139,6 +146,8 @@ impl Worker {
         }
 
         let (result, attempt) = self.delivery_service.deliver(&event, &config).await?;
+        self.observability
+            .emit_delivery_attempt(&event, &attempt, &result);
         self.dynamodb_service.record_attempt(attempt).await?;
         event.attempt_count += 1;
         self.dynamodb_service
@@ -216,6 +225,32 @@ impl Worker {
 
         info!("deleted SQS message");
         Ok(())
+    }
+
+    async fn emit_queue_depth_metric(&self) {
+        let result = self
+            .sqs_client
+            .get_queue_attributes()
+            .queue_url(&self.queue_url)
+            .attribute_names(sqs::types::QueueAttributeName::ApproximateNumberOfMessages)
+            .send()
+            .await;
+
+        match result {
+            Ok(output) => {
+                if let Some(attributes) = output.attributes() {
+                    if let Some(raw_depth) = attributes
+                        .get(&sqs::types::QueueAttributeName::ApproximateNumberOfMessages)
+                    {
+                        match raw_depth.parse::<i64>() {
+                            Ok(depth) => self.observability.emit_queue_depth(depth),
+                            Err(err) => warn!(error = %err, value = %raw_depth, "failed to parse queue depth"),
+                        }
+                    }
+                }
+            }
+            Err(err) => warn!(error = %err, "failed to sample queue depth"),
+        }
     }
 }
 #[tokio::main]

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -238,8 +238,8 @@ impl Worker {
 
         match result {
             Ok(output) => {
-                if let Some(attributes) = output.attributes() {
-                    if let Some(raw_depth) =
+                if let Some(attributes) = output.attributes()
+                    && let Some(raw_depth) =
                         attributes.get(&sqs::types::QueueAttributeName::ApproximateNumberOfMessages)
                     {
                         match raw_depth.parse::<i64>() {
@@ -249,7 +249,6 @@ impl Worker {
                             }
                         }
                     }
-                }
             }
             Err(err) => warn!(error = %err, "failed to sample queue depth"),
         }

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -241,14 +241,14 @@ impl Worker {
                 if let Some(attributes) = output.attributes()
                     && let Some(raw_depth) =
                         attributes.get(&sqs::types::QueueAttributeName::ApproximateNumberOfMessages)
-                    {
-                        match raw_depth.parse::<i64>() {
-                            Ok(depth) => self.observability.emit_queue_depth(depth),
-                            Err(err) => {
-                                warn!(error = %err, value = %raw_depth, "failed to parse queue depth")
-                            }
+                {
+                    match raw_depth.parse::<i64>() {
+                        Ok(depth) => self.observability.emit_queue_depth(depth),
+                        Err(err) => {
+                            warn!(error = %err, value = %raw_depth, "failed to parse queue depth")
                         }
                     }
+                }
             }
             Err(err) => warn!(error = %err, "failed to sample queue depth"),
         }

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -239,12 +239,14 @@ impl Worker {
         match result {
             Ok(output) => {
                 if let Some(attributes) = output.attributes() {
-                    if let Some(raw_depth) = attributes
-                        .get(&sqs::types::QueueAttributeName::ApproximateNumberOfMessages)
+                    if let Some(raw_depth) =
+                        attributes.get(&sqs::types::QueueAttributeName::ApproximateNumberOfMessages)
                     {
                         match raw_depth.parse::<i64>() {
                             Ok(depth) => self.observability.emit_queue_depth(depth),
-                            Err(err) => warn!(error = %err, value = %raw_depth, "failed to parse queue depth"),
+                            Err(err) => {
+                                warn!(error = %err, value = %raw_depth, "failed to parse queue depth")
+                            }
                         }
                     }
                 }

--- a/worker/src/observability.rs
+++ b/worker/src/observability.rs
@@ -15,7 +15,8 @@ pub struct Observability {
 
 impl Observability {
     pub fn new(queue_url: &str) -> Self {
-        let environment = env::var("ENVIRONMENT").unwrap_or_else(|_| DEFAULT_ENVIRONMENT.to_string());
+        let environment =
+            env::var("ENVIRONMENT").unwrap_or_else(|_| DEFAULT_ENVIRONMENT.to_string());
         let namespace =
             env::var("METRIC_NAMESPACE").unwrap_or_else(|_| DEFAULT_METRIC_NAMESPACE.to_string());
 
@@ -26,7 +27,12 @@ impl Observability {
         }
     }
 
-    pub fn emit_delivery_attempt(&self, event: &Event, attempt: &DeliveryAttempt, result: &DeliveryResult) {
+    pub fn emit_delivery_attempt(
+        &self,
+        event: &Event,
+        attempt: &DeliveryAttempt,
+        result: &DeliveryResult,
+    ) {
         let result_text = result.as_metric_label();
         let status_code = attempt
             .http_status
@@ -91,14 +97,17 @@ impl Observability {
         self.emit_metric("webhook.queue.depth", "Count", depth as f64, &dimensions);
     }
 
-    fn emit_metric(&self, metric_name: &str, unit: &str, value: f64, dimensions: &[(String, String)]) {
-        println!("{}", build_metric_payload(
-            &self.namespace,
-            metric_name,
-            unit,
-            value,
-            dimensions,
-        ));
+    fn emit_metric(
+        &self,
+        metric_name: &str,
+        unit: &str,
+        value: f64,
+        dimensions: &[(String, String)],
+    ) {
+        println!(
+            "{}",
+            build_metric_payload(&self.namespace, metric_name, unit, value, dimensions,)
+        );
     }
 }
 
@@ -168,8 +177,7 @@ mod tests {
 
     #[test]
     fn queue_name_parser_extracts_name() {
-        let queue_url =
-            "https://sqs.us-west-2.amazonaws.com/123456789012/webhook_delivery_dev";
+        let queue_url = "https://sqs.us-west-2.amazonaws.com/123456789012/webhook_delivery_dev";
         assert_eq!(queue_name_from_url(queue_url), "webhook_delivery_dev");
     }
 

--- a/worker/src/observability.rs
+++ b/worker/src/observability.rs
@@ -1,0 +1,202 @@
+use crate::model::{DeliveryAttempt, DeliveryResult, Event};
+use chrono::Utc;
+use serde_json::{Map, Value, json};
+use std::env;
+
+const DEFAULT_METRIC_NAMESPACE: &str = "HoorayRelay/Worker";
+const DEFAULT_ENVIRONMENT: &str = "dev";
+
+#[derive(Clone, Debug)]
+pub struct Observability {
+    environment: String,
+    queue_name: String,
+    namespace: String,
+}
+
+impl Observability {
+    pub fn new(queue_url: &str) -> Self {
+        let environment = env::var("ENVIRONMENT").unwrap_or_else(|_| DEFAULT_ENVIRONMENT.to_string());
+        let namespace =
+            env::var("METRIC_NAMESPACE").unwrap_or_else(|_| DEFAULT_METRIC_NAMESPACE.to_string());
+
+        Self {
+            environment,
+            queue_name: queue_name_from_url(queue_url),
+            namespace,
+        }
+    }
+
+    pub fn emit_delivery_attempt(&self, event: &Event, attempt: &DeliveryAttempt, result: &DeliveryResult) {
+        let result_text = result.as_metric_label();
+        let status_code = attempt
+            .http_status
+            .map(|status| status.to_string())
+            .unwrap_or_else(|| "none".to_string());
+
+        println!(
+            "{}",
+            json!({
+                "event_type": "delivery_attempt",
+                "event_id": event.event_id,
+                "customer_id": event.customer_id,
+                "attempt_number": attempt.attempt_number,
+                "result": result_text,
+                "http_status": attempt.http_status,
+                "latency_ms": attempt.response_time_ms,
+                "error": attempt.error_message,
+            })
+        );
+
+        let detailed_dims = vec![
+            ("environment".to_string(), self.environment.clone()),
+            ("queue_name".to_string(), self.queue_name.clone()),
+            ("customer_id".to_string(), event.customer_id.clone()),
+            ("status_code".to_string(), status_code.clone()),
+        ];
+        let aggregate_dims = vec![
+            ("environment".to_string(), self.environment.clone()),
+            ("queue_name".to_string(), self.queue_name.clone()),
+        ];
+
+        match result {
+            DeliveryResult::Success => {
+                self.emit_metric("webhook.delivery.success", "Count", 1.0, &detailed_dims);
+                self.emit_metric("webhook.delivery.success", "Count", 1.0, &aggregate_dims);
+            }
+            DeliveryResult::Retry | DeliveryResult::Exhausted => {
+                self.emit_metric("webhook.delivery.failure", "Count", 1.0, &detailed_dims);
+                self.emit_metric("webhook.delivery.failure", "Count", 1.0, &aggregate_dims);
+            }
+        }
+
+        self.emit_metric(
+            "webhook.delivery.latency_ms",
+            "Milliseconds",
+            attempt.response_time_ms as f64,
+            &detailed_dims,
+        );
+        self.emit_metric(
+            "webhook.delivery.latency_ms",
+            "Milliseconds",
+            attempt.response_time_ms as f64,
+            &aggregate_dims,
+        );
+    }
+
+    pub fn emit_queue_depth(&self, depth: i64) {
+        let dimensions = vec![
+            ("environment".to_string(), self.environment.clone()),
+            ("queue_name".to_string(), self.queue_name.clone()),
+        ];
+        self.emit_metric("webhook.queue.depth", "Count", depth as f64, &dimensions);
+    }
+
+    fn emit_metric(&self, metric_name: &str, unit: &str, value: f64, dimensions: &[(String, String)]) {
+        println!("{}", build_metric_payload(
+            &self.namespace,
+            metric_name,
+            unit,
+            value,
+            dimensions,
+        ));
+    }
+}
+
+fn queue_name_from_url(queue_url: &str) -> String {
+    queue_url
+        .trim_end_matches('/')
+        .rsplit('/')
+        .next()
+        .filter(|name| !name.is_empty())
+        .unwrap_or("unknown-queue")
+        .to_string()
+}
+
+fn build_metric_payload(
+    namespace: &str,
+    metric_name: &str,
+    unit: &str,
+    value: f64,
+    dimensions: &[(String, String)],
+) -> Value {
+    let mut root = Map::new();
+    let dimension_keys: Vec<Value> = dimensions
+        .iter()
+        .map(|(key, _)| Value::String(key.clone()))
+        .collect();
+
+    for (key, value_text) in dimensions {
+        root.insert(key.clone(), Value::String(value_text.clone()));
+    }
+
+    root.insert(metric_name.to_string(), Value::from(value));
+    root.insert(
+        "_aws".to_string(),
+        json!({
+            "Timestamp": Utc::now().timestamp_millis(),
+            "CloudWatchMetrics": [{
+                "Namespace": namespace,
+                "Dimensions": [dimension_keys],
+                "Metrics": [{
+                    "Name": metric_name,
+                    "Unit": unit
+                }]
+            }]
+        }),
+    );
+
+    Value::Object(root)
+}
+
+trait DeliveryResultMetricLabel {
+    fn as_metric_label(&self) -> &'static str;
+}
+
+impl DeliveryResultMetricLabel for DeliveryResult {
+    fn as_metric_label(&self) -> &'static str {
+        match self {
+            DeliveryResult::Success => "success",
+            DeliveryResult::Retry => "retry",
+            DeliveryResult::Exhausted => "exhausted",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn queue_name_parser_extracts_name() {
+        let queue_url =
+            "https://sqs.us-west-2.amazonaws.com/123456789012/webhook_delivery_dev";
+        assert_eq!(queue_name_from_url(queue_url), "webhook_delivery_dev");
+    }
+
+    #[test]
+    fn queue_name_parser_falls_back_when_missing_segments() {
+        assert_eq!(queue_name_from_url(""), "unknown-queue");
+    }
+
+    #[test]
+    fn metric_payload_contains_name_and_dimensions() {
+        let payload = build_metric_payload(
+            "HoorayRelay/Worker",
+            "webhook.delivery.success",
+            "Count",
+            1.0,
+            &[
+                ("environment".to_string(), "dev".to_string()),
+                ("queue_name".to_string(), "queue-a".to_string()),
+            ],
+        );
+
+        assert_eq!(payload["webhook.delivery.success"], 1.0);
+        assert_eq!(payload["environment"], "dev");
+        assert_eq!(payload["queue_name"], "queue-a");
+        assert_eq!(
+            payload["_aws"]["CloudWatchMetrics"][0]["Metrics"][0]["Name"],
+            "webhook.delivery.success"
+        );
+    }
+}


### PR DESCRIPTION

This pull request introduces comprehensive Day 6 observability for the delivery worker, adding CloudWatch monitoring, metrics, dashboards, alarms, and verification scripts. The changes span documentation, infrastructure artifacts, and worker code to ensure robust visibility and operational readiness.

**Monitoring and Observability Enhancements**

* Added CloudWatch dashboard and alarms for delivery success/failure rates, latency (p95), and queue depth, with supporting JSON artifacts in `monitoring/` and documentation on how to apply them. [[1]](diffhunk://#diff-b3733cfb0205dddee17d6d481d77fc6d72ac116e15e7f7713a2ec5a45283f95eR1-R29) [[2]](diffhunk://#diff-17d4c6d1a225d189e39683ec47c3903200a96fd157c5db7b488a13038aea7891R1-R48) [[3]](diffhunk://#diff-925e61efe1a35fcacda6b8539fbc4cc0ec3a95852b3cc8fcba9884fd9c680dfeR1-R16) [[4]](diffhunk://#diff-dd3e909e1d71618ddd6a7dd30a68886463a27878a3d6971d37fe99ad678a2ee0R1-R75)
* Introduced `scripts/e2e_day6_observability.sh` for automated verification of metrics, logs, and alarm presence, ensuring observability signals are emitted and visible in CloudWatch.

**Worker Code Updates for Metrics**

* Integrated new `observability` module in `worker/src/main.rs`, emitting custom metrics (delivery attempts, queue depth) and structured logs for each delivery attempt. [[1]](diffhunk://#diff-3381a66150dcfc521726bae16533dcb6463f5f799ba999a2f972bee40756a6bbR2-R6) [[2]](diffhunk://#diff-3381a66150dcfc521726bae16533dcb6463f5f799ba999a2f972bee40756a6bbR25) [[3]](diffhunk://#diff-3381a66150dcfc521726bae16533dcb6463f5f799ba999a2f972bee40756a6bbR56) [[4]](diffhunk://#diff-3381a66150dcfc521726bae16533dcb6463f5f799ba999a2f972bee40756a6bbR78-R79) [[5]](diffhunk://#diff-3381a66150dcfc521726bae16533dcb6463f5f799ba999a2f972bee40756a6bbR105) [[6]](diffhunk://#diff-3381a66150dcfc521726bae16533dcb6463f5f799ba999a2f972bee40756a6bbR149-R150)

**Documentation and Timeline Updates**

* Updated `README.md` and `docs/ENGINEER_2_TIMELINE.md` to reflect the new monitoring workflow, runtime split, and completed Day 6 tasks (metrics, dashboard, alarms, e2e scripts). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L2-R7) [[2]](diffhunk://#diff-22ecc3dbdef666f8f25efce96997f4e2e0139ec2ba129af9e91530de5e1980ddL178-R178) [[3]](diffhunk://#diff-22ecc3dbdef666f8f25efce96997f4e2e0139ec2ba129af9e91530de5e1980ddL191-R191) [[4]](diffhunk://#diff-22ecc3dbdef666f8f25efce96997f4e2e0139ec2ba129af9e91530de5e1980ddL226-R245) [[5]](diffhunk://#diff-22ecc3dbdef666f8f25efce96997f4e2e0139ec2ba129af9e91530de5e1980ddL417-R425)

**Build and Deployment Adjustments**

* Removed Lambda-specific worker packaging and deployment targets from `Makefile` and `.envrc.example`, clarifying that the worker now runs as a long-lived SQS poller for MVP (not Lambda). [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L1-L17) [[2]](diffhunk://#diff-3082ae36c8f15de3efeca6f847e54b67eed544428c38704187a0cdb50382a282L30-L34)

These changes collectively ensure that the delivery worker emits all required metrics and logs, and that operational teams can monitor, alert, and troubleshoot effectively using CloudWatch.