### PR TITLE
ci: fix SAM workflow action setup

### DIFF
--- a/.github/workflows/sam.yml
+++ b/.github/workflows/sam.yml
@@ -36,8 +36,13 @@ jobs:
       - name: Setup SAM CLI
         uses: aws-actions/setup-sam@v2
 
-      - name: Install cargo-lambda
-        uses: cargo-lambda/setup-cargo-lambda@v2
+      - name: Install Cargo Lambda
+        uses: moonrepo/setup-rust@v1
+        with:
+          bins: cargo-lambda
+
+      - name: Install Zig
+        uses: mlugg/setup-zig@v1
 
       - name: Validate SAM template
         run: sam validate --lint

--- a/.github/workflows/sam.yml
+++ b/.github/workflows/sam.yml
@@ -45,6 +45,8 @@ jobs:
 
       - name: Install Zig
         uses: mlugg/setup-zig@v1
+        with:
+          version: 0.11.0
 
       - name: Validate SAM template
         run: sam validate --lint

--- a/.github/workflows/sam.yml
+++ b/.github/workflows/sam.yml
@@ -4,6 +4,8 @@ name: SAM CI
 "on":
   push:
     branches: ["main"]
+  pull_request:
+    branches: ["main"]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary
- replace invalid cargo-lambda setup action with supported installer
- add Zig setup required for cargo-lambda ARM64 builds

## Why
SAM CI failed because the workflow referenced an invalid/unsupported action for cargo-lambda installation.

## Validation
- YAML parses successfully
- workflow now uses valid action references