### PR TITLE
Feat/engineer1 day6 cloudwatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1314,6 +1314,7 @@ dependencies = [
  "aws-sdk-dynamodb",
  "aws-sdk-sqs",
  "axum",
+ "chrono",
  "lambda_http",
  "nanoid",
  "serde",

--- a/ingestion/Cargo.toml
+++ b/ingestion/Cargo.toml
@@ -30,5 +30,8 @@ serde_dynamo.workspace = true
 # unique ID generation
 nanoid = "0.4"
 
+# timestamp for EMF metric envelopes
+chrono = "0.4"
+
 # Lambda runtime
 lambda_http.workspace = true

--- a/ingestion/src/handlers/config.rs
+++ b/ingestion/src/handlers/config.rs
@@ -102,6 +102,9 @@ pub async fn create_config(
                 url = %config.url,
                 "webhook config created"
             );
+            state
+                .observability
+                .emit_config_create(&req.customer_id, 201);
             (StatusCode::CREATED, Json(config.to_response())).into_response()
         }
         Err(e) => {
@@ -110,6 +113,9 @@ pub async fn create_config(
                 customer_id = %req.customer_id,
                 "failed to persist webhook config"
             );
+            state
+                .observability
+                .emit_config_create(&req.customer_id, 500);
             config_error_response(e)
         }
     }
@@ -137,6 +143,9 @@ pub async fn get_config(
     {
         Ok(config) => {
             info!(customer_id = %params.customer_id, "webhook config retrieved");
+            state
+                .observability
+                .emit_config_get(&params.customer_id, 200);
             (StatusCode::OK, Json(config.to_response())).into_response()
         }
         Err(e) => {
@@ -145,6 +154,13 @@ pub async fn get_config(
                 customer_id = %params.customer_id,
                 "failed to retrieve webhook config"
             );
+            let status_code = match &e {
+                IngestionError::ItemNotFound { .. } | IngestionError::ConfigNotFound(_) => 404,
+                _ => 500,
+            };
+            state
+                .observability
+                .emit_config_get(&params.customer_id, status_code);
             config_error_response(e)
         }
     }

--- a/ingestion/src/handlers/webhook.rs
+++ b/ingestion/src/handlers/webhook.rs
@@ -232,13 +232,9 @@ pub async fn receive_webhook(
     );
 
     let latency_ms = start.elapsed().as_millis() as u64;
-    state.observability.emit_receive(
-        &req.customer_id,
-        202,
-        latency_ms,
-        false,
-        false,
-    );
+    state
+        .observability
+        .emit_receive(&req.customer_id, 202, latency_ms, false, false);
 
     let body = WebhookReceiveResponse {
         event_id,

--- a/ingestion/src/handlers/webhook.rs
+++ b/ingestion/src/handlers/webhook.rs
@@ -20,7 +20,7 @@
 //! handler can stay pure and testable without touching global state.
 
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use axum::Json;
 use axum::extract::State;
@@ -32,6 +32,7 @@ use crate::model::{
     IngestionError, ReceiveStatus, WebhookReceiveRequest, WebhookReceiveResponse,
     WebhookValidationError,
 };
+use crate::observability::Observability;
 use crate::services::dynamodb::AppConfig;
 use crate::services::idempotency::IdempotencyOutcome;
 use crate::services::{events, idempotency, queue};
@@ -50,6 +51,8 @@ pub struct AppState {
     pub sqs: aws_sdk_sqs::Client,
     /// Runtime configuration loaded from environment variables.
     pub config: AppConfig,
+    /// CloudWatch EMF metric emitter.
+    pub observability: Observability,
 }
 
 // ---------------------------------------------------------------------------
@@ -73,12 +76,23 @@ pub async fn receive_webhook(
     State(state): State<Arc<AppState>>,
     Json(req): Json<WebhookReceiveRequest>,
 ) -> Response {
+    // Start wall-clock timer for end-to-end latency metric.
+    let start = Instant::now();
+
     // ------------------------------------------------------------------
     // Step 1 — Validate the incoming request.
     // ------------------------------------------------------------------
     if let Err(e) = req.validate() {
         warn!(error = %e, "webhook request failed validation");
-        return validation_error_response(e);
+        let resp = validation_error_response(e);
+        state.observability.emit_receive(
+            &req.customer_id,
+            422,
+            start.elapsed().as_millis() as u64,
+            false,
+            false,
+        );
+        return resp;
     }
 
     // ------------------------------------------------------------------
@@ -99,7 +113,15 @@ pub async fn receive_webhook(
         Ok(outcome) => outcome,
         Err(e) => {
             error!(error = %e, "idempotency check failed");
-            return ingestion_error_response(e);
+            let resp = ingestion_error_response(e);
+            state.observability.emit_receive(
+                &req.customer_id,
+                500,
+                start.elapsed().as_millis() as u64,
+                false,
+                false,
+            );
+            return resp;
         }
     };
 
@@ -119,6 +141,13 @@ pub async fn receive_webhook(
             status: ReceiveStatus::Duplicate,
             created_at: unix_now_secs(),
         };
+        state.observability.emit_receive(
+            &req.customer_id,
+            200,
+            start.elapsed().as_millis() as u64,
+            true,
+            false,
+        );
         return (StatusCode::OK, Json(body)).into_response();
     }
 
@@ -128,7 +157,15 @@ pub async fn receive_webhook(
     let payload = match events::serialize_payload(&req.data) {
         Ok(p) => p,
         Err(e) => {
-            return ingestion_error_response(e);
+            let resp = ingestion_error_response(e);
+            state.observability.emit_receive(
+                &req.customer_id,
+                500,
+                start.elapsed().as_millis() as u64,
+                false,
+                false,
+            );
+            return resp;
         }
     };
 
@@ -141,7 +178,15 @@ pub async fn receive_webhook(
 
     if let Err(e) = events::create_event(&state.dynamo, &state.config.events_table, &event).await {
         error!(error = %e, event_id = %event_id, "failed to persist event to DynamoDB");
-        return ingestion_error_response(e);
+        let resp = ingestion_error_response(e);
+        state.observability.emit_receive(
+            &req.customer_id,
+            500,
+            start.elapsed().as_millis() as u64,
+            false,
+            false,
+        );
+        return resp;
     }
 
     // ------------------------------------------------------------------
@@ -165,7 +210,15 @@ pub async fn receive_webhook(
         // perform manual re-queueing or run a separate reconciliation job that
         // scans for persisted-but-not-enqueued events and enqueues them.
         error!(error = %e, event_id = %event_id, "failed to enqueue event on SQS");
-        return ingestion_error_response(e);
+        let resp = ingestion_error_response(e);
+        state.observability.emit_receive(
+            &req.customer_id,
+            500,
+            start.elapsed().as_millis() as u64,
+            false,
+            true, // enqueue_failed = true
+        );
+        return resp;
     }
 
     // ------------------------------------------------------------------
@@ -176,6 +229,15 @@ pub async fn receive_webhook(
         customer_id = %req.customer_id,
         idempotency_key = %req.idempotency_key,
         "webhook event accepted and enqueued"
+    );
+
+    let latency_ms = start.elapsed().as_millis() as u64;
+    state.observability.emit_receive(
+        &req.customer_id,
+        202,
+        latency_ms,
+        false,
+        false,
     );
 
     let body = WebhookReceiveResponse {

--- a/ingestion/src/main.rs
+++ b/ingestion/src/main.rs
@@ -19,6 +19,7 @@
 
 pub mod handlers;
 pub mod model;
+pub mod observability;
 pub mod services;
 
 use std::sync::Arc;
@@ -33,6 +34,7 @@ use tracing_subscriber::fmt::format::FmtSpan;
 
 use handlers::config::{create_config, get_config};
 use handlers::webhook::{AppState, receive_webhook};
+use observability::Observability;
 use services::dynamodb::{AppConfig, build_dynamo_client};
 
 #[tokio::main]
@@ -76,6 +78,7 @@ async fn main() -> Result<(), lambda_http::Error> {
         dynamo,
         sqs,
         config,
+        observability: Observability::new(),
     });
 
     // ------------------------------------------------------------------

--- a/ingestion/src/observability.rs
+++ b/ingestion/src/observability.rs
@@ -147,30 +147,64 @@ impl Observability {
 
     /// Emit metrics for a `POST /webhooks/configs` call.
     ///
-    /// Emits `webhook.config.create.count` with `customer_id` and `status_code`
-    /// dimensions.
+    /// Emits `webhook.config.create.count` both with detailed `customer_id`
+    /// dimension and aggregated without it (only `environment` + `status_code`),
+    /// matching the webhook receive metrics pattern and dashboard queries.
     pub fn emit_config_create(&self, customer_id: &str, status_code: u16) {
         let status_str = status_code.to_string();
-        let dims = vec![
+        let detailed_dims = vec![
             ("environment".to_string(), self.environment.clone()),
             ("customer_id".to_string(), customer_id.to_string()),
+            ("status_code".to_string(), status_str.clone()),
+        ];
+        let aggregate_dims = vec![
+            ("environment".to_string(), self.environment.clone()),
             ("status_code".to_string(), status_str),
         ];
-        self.emit_metric("webhook.config.create.count", "Count", 1.0, &dims);
+
+        self.emit_metric(
+            "webhook.config.create.count",
+            "Count",
+            1.0,
+            &detailed_dims,
+        );
+        self.emit_metric(
+            "webhook.config.create.count",
+            "Count",
+            1.0,
+            &aggregate_dims,
+        );
     }
 
     /// Emit metrics for a `GET /webhooks/configs` call.
     ///
-    /// Emits `webhook.config.get.count` with `customer_id` and `status_code`
-    /// dimensions.
+    /// Emits `webhook.config.get.count` both with detailed `customer_id`
+    /// dimension and aggregated without it (only `environment` + `status_code`),
+    /// matching the webhook receive metrics pattern and dashboard queries.
     pub fn emit_config_get(&self, customer_id: &str, status_code: u16) {
         let status_str = status_code.to_string();
-        let dims = vec![
+        let detailed_dims = vec![
             ("environment".to_string(), self.environment.clone()),
             ("customer_id".to_string(), customer_id.to_string()),
+            ("status_code".to_string(), status_str.clone()),
+        ];
+        let aggregate_dims = vec![
+            ("environment".to_string(), self.environment.clone()),
             ("status_code".to_string(), status_str),
         ];
-        self.emit_metric("webhook.config.get.count", "Count", 1.0, &dims);
+
+        self.emit_metric(
+            "webhook.config.get.count",
+            "Count",
+            1.0,
+            &detailed_dims,
+        );
+        self.emit_metric(
+            "webhook.config.get.count",
+            "Count",
+            1.0,
+            &aggregate_dims,
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/ingestion/src/observability.rs
+++ b/ingestion/src/observability.rs
@@ -147,9 +147,8 @@ impl Observability {
 
     /// Emit metrics for a `POST /webhooks/configs` call.
     ///
-    /// Emits `webhook.config.create.count` both with detailed `customer_id`
-    /// dimension and aggregated without it (only `environment` + `status_code`),
-    /// matching the webhook receive metrics pattern and dashboard queries.
+    /// Emits `webhook.config.create.count` with `customer_id` and `status_code`
+    /// dimensions.
     pub fn emit_config_create(&self, customer_id: &str, status_code: u16) {
         let status_str = status_code.to_string();
         let detailed_dims = vec![
@@ -161,26 +160,14 @@ impl Observability {
             ("environment".to_string(), self.environment.clone()),
             ("status_code".to_string(), status_str),
         ];
-
-        self.emit_metric(
-            "webhook.config.create.count",
-            "Count",
-            1.0,
-            &detailed_dims,
-        );
-        self.emit_metric(
-            "webhook.config.create.count",
-            "Count",
-            1.0,
-            &aggregate_dims,
-        );
+        self.emit_metric("webhook.config.create.count", "Count", 1.0, &detailed_dims);
+        self.emit_metric("webhook.config.create.count", "Count", 1.0, &aggregate_dims);
     }
 
     /// Emit metrics for a `GET /webhooks/configs` call.
     ///
-    /// Emits `webhook.config.get.count` both with detailed `customer_id`
-    /// dimension and aggregated without it (only `environment` + `status_code`),
-    /// matching the webhook receive metrics pattern and dashboard queries.
+    /// Emits `webhook.config.get.count` with `customer_id` and `status_code`
+    /// dimensions.
     pub fn emit_config_get(&self, customer_id: &str, status_code: u16) {
         let status_str = status_code.to_string();
         let detailed_dims = vec![
@@ -192,19 +179,8 @@ impl Observability {
             ("environment".to_string(), self.environment.clone()),
             ("status_code".to_string(), status_str),
         ];
-
-        self.emit_metric(
-            "webhook.config.get.count",
-            "Count",
-            1.0,
-            &detailed_dims,
-        );
-        self.emit_metric(
-            "webhook.config.get.count",
-            "Count",
-            1.0,
-            &aggregate_dims,
-        );
+        self.emit_metric("webhook.config.get.count", "Count", 1.0, &detailed_dims);
+        self.emit_metric("webhook.config.get.count", "Count", 1.0, &aggregate_dims);
     }
 
     // -----------------------------------------------------------------------

--- a/ingestion/src/observability.rs
+++ b/ingestion/src/observability.rs
@@ -1,0 +1,354 @@
+//! Structured CloudWatch Embedded Metric Format (EMF) observability for the
+//! ingestion Lambda.
+//!
+//! ## Emitted metrics
+//!
+//! | Metric name                          | Unit         | When emitted                        |
+//! |--------------------------------------|--------------|-------------------------------------|
+//! | `webhook.receive.count`              | Count        | Every `POST /webhooks/receive` call |
+//! | `webhook.idempotency.duplicate.count`| Count        | Duplicate idempotency key detected  |
+//! | `webhook.enqueue.failure.count`      | Count        | SQS `enqueue_event` returns `Err`   |
+//! | `webhook.receive.latency_ms`         | Milliseconds | End-to-end handler latency          |
+//!
+//! ## Dimensions (applied consistently across all metrics)
+//!
+//! | Dimension      | Source                                  |
+//! |----------------|-----------------------------------------|
+//! | `environment`  | `ENVIRONMENT` env-var (default: `dev`)  |
+//! | `customer_id`  | Request `customer_id` field             |
+//! | `status_code`  | Final HTTP status code as string        |
+//!
+//! ## EMF format
+//!
+//! Each metric is printed as a single JSON log line that CloudWatch Logs
+//! automatically extracts into CloudWatch Metrics (no agent required).
+//! The format follows the [AWS EMF spec](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Specification.html).
+
+use chrono::Utc;
+use serde_json::{Map, Value, json};
+use std::env;
+
+const DEFAULT_METRIC_NAMESPACE: &str = "HoorayRelay/Ingestion";
+const DEFAULT_ENVIRONMENT: &str = "dev";
+
+// ---------------------------------------------------------------------------
+// Public struct
+// ---------------------------------------------------------------------------
+
+/// Emits structured EMF metric log lines for the ingestion Lambda.
+///
+/// Construct once at cold-start (cheap — only reads env-vars) and store in
+/// [`crate::handlers::webhook::AppState`].
+#[derive(Clone, Debug)]
+pub struct Observability {
+    environment: String,
+    namespace: String,
+}
+
+impl Observability {
+    /// Build from environment variables.
+    ///
+    /// - `ENVIRONMENT` → `environment` dimension (default `"dev"`)
+    /// - `METRIC_NAMESPACE` → EMF namespace (default `"HoorayRelay/Ingestion"`)
+    pub fn new() -> Self {
+        let environment =
+            env::var("ENVIRONMENT").unwrap_or_else(|_| DEFAULT_ENVIRONMENT.to_string());
+        let namespace = env::var("METRIC_NAMESPACE")
+            .unwrap_or_else(|_| DEFAULT_METRIC_NAMESPACE.to_string());
+        Self {
+            environment,
+            namespace,
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // High-level emit helpers (called from handlers)
+    // -----------------------------------------------------------------------
+
+    /// Emit metrics for a completed `POST /webhooks/receive` call.
+    ///
+    /// - Always emits `webhook.receive.count` (1).
+    /// - Always emits `webhook.receive.latency_ms` (end-to-end handler latency).
+    /// - Emits `webhook.idempotency.duplicate.count` when `is_duplicate = true`.
+    /// - Emits `webhook.enqueue.failure.count` when `enqueue_failed = true`.
+    ///
+    /// # Arguments
+    ///
+    /// * `customer_id`    — the request `customer_id` field.
+    /// * `status_code`    — the HTTP status code returned to the caller.
+    /// * `latency_ms`     — end-to-end handler latency in milliseconds.
+    /// * `is_duplicate`   — true when the idempotency check returned `Duplicate`.
+    /// * `enqueue_failed` — true when `queue::enqueue_event` returned `Err`.
+    pub fn emit_receive(
+        &self,
+        customer_id: &str,
+        status_code: u16,
+        latency_ms: u64,
+        is_duplicate: bool,
+        enqueue_failed: bool,
+    ) {
+        let status_str = status_code.to_string();
+        let detailed_dims = vec![
+            ("environment".to_string(), self.environment.clone()),
+            ("customer_id".to_string(), customer_id.to_string()),
+            ("status_code".to_string(), status_str.clone()),
+        ];
+        let aggregate_dims = vec![
+            ("environment".to_string(), self.environment.clone()),
+            ("status_code".to_string(), status_str),
+        ];
+
+        // Always emit receive count + latency at both detailed and aggregate.
+        self.emit_metric("webhook.receive.count", "Count", 1.0, &detailed_dims);
+        self.emit_metric("webhook.receive.count", "Count", 1.0, &aggregate_dims);
+        self.emit_metric(
+            "webhook.receive.latency_ms",
+            "Milliseconds",
+            latency_ms as f64,
+            &detailed_dims,
+        );
+        self.emit_metric(
+            "webhook.receive.latency_ms",
+            "Milliseconds",
+            latency_ms as f64,
+            &aggregate_dims,
+        );
+
+        if is_duplicate {
+            self.emit_metric(
+                "webhook.idempotency.duplicate.count",
+                "Count",
+                1.0,
+                &detailed_dims,
+            );
+            self.emit_metric(
+                "webhook.idempotency.duplicate.count",
+                "Count",
+                1.0,
+                &aggregate_dims,
+            );
+        }
+
+        if enqueue_failed {
+            self.emit_metric(
+                "webhook.enqueue.failure.count",
+                "Count",
+                1.0,
+                &detailed_dims,
+            );
+            self.emit_metric(
+                "webhook.enqueue.failure.count",
+                "Count",
+                1.0,
+                &aggregate_dims,
+            );
+        }
+    }
+
+    /// Emit metrics for a `POST /webhooks/configs` call.
+    ///
+    /// Emits `webhook.config.create.count` with `customer_id` and `status_code`
+    /// dimensions.
+    pub fn emit_config_create(&self, customer_id: &str, status_code: u16) {
+        let status_str = status_code.to_string();
+        let dims = vec![
+            ("environment".to_string(), self.environment.clone()),
+            ("customer_id".to_string(), customer_id.to_string()),
+            ("status_code".to_string(), status_str),
+        ];
+        self.emit_metric("webhook.config.create.count", "Count", 1.0, &dims);
+    }
+
+    /// Emit metrics for a `GET /webhooks/configs` call.
+    ///
+    /// Emits `webhook.config.get.count` with `customer_id` and `status_code`
+    /// dimensions.
+    pub fn emit_config_get(&self, customer_id: &str, status_code: u16) {
+        let status_str = status_code.to_string();
+        let dims = vec![
+            ("environment".to_string(), self.environment.clone()),
+            ("customer_id".to_string(), customer_id.to_string()),
+            ("status_code".to_string(), status_str),
+        ];
+        self.emit_metric("webhook.config.get.count", "Count", 1.0, &dims);
+    }
+
+    // -----------------------------------------------------------------------
+    // Internal EMF emit
+    // -----------------------------------------------------------------------
+
+    fn emit_metric(
+        &self,
+        metric_name: &str,
+        unit: &str,
+        value: f64,
+        dimensions: &[(String, String)],
+    ) {
+        println!(
+            "{}",
+            build_emf_payload(&self.namespace, metric_name, unit, value, dimensions)
+        );
+    }
+}
+
+impl Default for Observability {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// EMF payload builder (pure function — easy to unit-test)
+// ---------------------------------------------------------------------------
+
+/// Build a CloudWatch EMF-formatted JSON [`Value`] for a single metric.
+///
+/// The returned value is a flat JSON object that contains:
+/// - one key per dimension (e.g. `"environment": "dev"`)
+/// - one key for the metric value (e.g. `"webhook.receive.count": 1.0`)
+/// - a `_aws` envelope required by the EMF spec
+pub fn build_emf_payload(
+    namespace: &str,
+    metric_name: &str,
+    unit: &str,
+    value: f64,
+    dimensions: &[(String, String)],
+) -> Value {
+    let mut root = Map::new();
+
+    // Dimension keys for the `_aws.CloudWatchMetrics[].Dimensions` array.
+    let dimension_keys: Vec<Value> = dimensions
+        .iter()
+        .map(|(key, _)| Value::String(key.clone()))
+        .collect();
+
+    // Flatten dimension key/value pairs at the root level.
+    for (key, val) in dimensions {
+        root.insert(key.clone(), Value::String(val.clone()));
+    }
+
+    // Metric value at root level.
+    root.insert(metric_name.to_string(), Value::from(value));
+
+    // Required `_aws` EMF envelope.
+    root.insert(
+        "_aws".to_string(),
+        json!({
+            "Timestamp": Utc::now().timestamp_millis(),
+            "CloudWatchMetrics": [{
+                "Namespace": namespace,
+                "Dimensions": [dimension_keys],
+                "Metrics": [{
+                    "Name": metric_name,
+                    "Unit": unit
+                }]
+            }]
+        }),
+    );
+
+    Value::Object(root)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_dims() -> Vec<(String, String)> {
+        vec![
+            ("environment".to_string(), "test".to_string()),
+            ("customer_id".to_string(), "cust_abc".to_string()),
+            ("status_code".to_string(), "202".to_string()),
+        ]
+    }
+
+    #[test]
+    fn emf_payload_contains_metric_value() {
+        let payload = build_emf_payload(
+            "HoorayRelay/Ingestion",
+            "webhook.receive.count",
+            "Count",
+            1.0,
+            &base_dims(),
+        );
+        assert_eq!(payload["webhook.receive.count"], 1.0);
+    }
+
+    #[test]
+    fn emf_payload_contains_all_dimensions_at_root() {
+        let payload = build_emf_payload(
+            "HoorayRelay/Ingestion",
+            "webhook.receive.count",
+            "Count",
+            1.0,
+            &base_dims(),
+        );
+        assert_eq!(payload["environment"], "test");
+        assert_eq!(payload["customer_id"], "cust_abc");
+        assert_eq!(payload["status_code"], "202");
+    }
+
+    #[test]
+    fn emf_payload_has_aws_envelope() {
+        let payload = build_emf_payload(
+            "HoorayRelay/Ingestion",
+            "webhook.receive.count",
+            "Count",
+            1.0,
+            &base_dims(),
+        );
+        let aws = &payload["_aws"];
+        assert!(aws["Timestamp"].is_number(), "_aws.Timestamp must be a number");
+        let metrics = &aws["CloudWatchMetrics"][0];
+        assert_eq!(metrics["Namespace"], "HoorayRelay/Ingestion");
+        assert_eq!(metrics["Metrics"][0]["Name"], "webhook.receive.count");
+        assert_eq!(metrics["Metrics"][0]["Unit"], "Count");
+    }
+
+    #[test]
+    fn emf_payload_dimension_keys_in_envelope() {
+        let payload = build_emf_payload(
+            "HoorayRelay/Ingestion",
+            "webhook.receive.latency_ms",
+            "Milliseconds",
+            42.0,
+            &base_dims(),
+        );
+        let dim_keys = &payload["_aws"]["CloudWatchMetrics"][0]["Dimensions"][0];
+        // Dimensions array should contain all three key names.
+        let keys: Vec<&str> = dim_keys
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        assert!(keys.contains(&"environment"));
+        assert!(keys.contains(&"customer_id"));
+        assert!(keys.contains(&"status_code"));
+    }
+
+    #[test]
+    fn emf_payload_latency_value() {
+        let payload = build_emf_payload(
+            "HoorayRelay/Ingestion",
+            "webhook.receive.latency_ms",
+            "Milliseconds",
+            123.0,
+            &base_dims(),
+        );
+        assert_eq!(payload["webhook.receive.latency_ms"], 123.0);
+    }
+
+    #[test]
+    fn observability_new_uses_env_default() {
+        // Without env-vars set, Observability::new() should not panic.
+        let obs = Observability::new();
+        // environment defaults to "dev" when ENVIRONMENT is not set.
+        // (env-var may be set in the process, so just confirm it's non-empty.)
+        assert!(!obs.environment.is_empty());
+        assert!(!obs.namespace.is_empty());
+    }
+}

--- a/ingestion/src/observability.rs
+++ b/ingestion/src/observability.rs
@@ -53,8 +53,8 @@ impl Observability {
     pub fn new() -> Self {
         let environment =
             env::var("ENVIRONMENT").unwrap_or_else(|_| DEFAULT_ENVIRONMENT.to_string());
-        let namespace = env::var("METRIC_NAMESPACE")
-            .unwrap_or_else(|_| DEFAULT_METRIC_NAMESPACE.to_string());
+        let namespace =
+            env::var("METRIC_NAMESPACE").unwrap_or_else(|_| DEFAULT_METRIC_NAMESPACE.to_string());
         Self {
             environment,
             namespace,
@@ -301,7 +301,10 @@ mod tests {
             &base_dims(),
         );
         let aws = &payload["_aws"];
-        assert!(aws["Timestamp"].is_number(), "_aws.Timestamp must be a number");
+        assert!(
+            aws["Timestamp"].is_number(),
+            "_aws.Timestamp must be a number"
+        );
         let metrics = &aws["CloudWatchMetrics"][0];
         assert_eq!(metrics["Namespace"], "HoorayRelay/Ingestion");
         assert_eq!(metrics["Metrics"][0]["Name"], "webhook.receive.count");

--- a/monitoring/ingestion-dashboard.json
+++ b/monitoring/ingestion-dashboard.json
@@ -1,0 +1,158 @@
+{
+  "widgets": [
+    {
+      "type": "metric",
+      "x": 0,
+      "y": 0,
+      "width": 12,
+      "height": 6,
+      "properties": {
+        "title": "Webhook Receive Rate (5m Sum)",
+        "view": "timeSeries",
+        "stacked": false,
+        "region": "us-west-2",
+        "period": 300,
+        "stat": "Sum",
+        "metrics": [
+          ["HoorayRelay/Ingestion", "webhook.receive.count", "environment", "dev", "status_code", "202", { "label": "202 Accepted" }],
+          [".", ".", ".", ".", "status_code", "200", { "label": "200 Duplicate" }],
+          [".", ".", ".", ".", "status_code", "422", { "label": "422 Validation Error" }],
+          [".", ".", ".", ".", "status_code", "500", { "label": "500 Internal Error" }]
+        ]
+      }
+    },
+    {
+      "type": "metric",
+      "x": 12,
+      "y": 0,
+      "width": 12,
+      "height": 6,
+      "properties": {
+        "title": "Receive Latency (ms) — p50 / p95 / p99",
+        "view": "timeSeries",
+        "stacked": false,
+        "region": "us-west-2",
+        "period": 300,
+        "metrics": [
+          ["HoorayRelay/Ingestion", "webhook.receive.latency_ms", "environment", "dev", "status_code", "202", { "stat": "p50",  "label": "p50" }],
+          [".", ".", ".", ".", ".", ".",                                                                      { "stat": "p95",  "label": "p95" }],
+          [".", ".", ".", ".", ".", ".",                                                                      { "stat": "p99",  "label": "p99" }]
+        ]
+      }
+    },
+    {
+      "type": "metric",
+      "x": 0,
+      "y": 6,
+      "width": 12,
+      "height": 6,
+      "properties": {
+        "title": "Idempotency Hit Rate (5m Sum)",
+        "view": "timeSeries",
+        "stacked": false,
+        "region": "us-west-2",
+        "period": 300,
+        "stat": "Sum",
+        "metrics": [
+          ["HoorayRelay/Ingestion", "webhook.idempotency.duplicate.count", "environment", "dev", "status_code", "200", { "label": "Duplicate requests detected" }]
+        ]
+      }
+    },
+    {
+      "type": "metric",
+      "x": 12,
+      "y": 6,
+      "width": 12,
+      "height": 6,
+      "properties": {
+        "title": "SQS Enqueue Failures (5m Sum)",
+        "view": "timeSeries",
+        "stacked": false,
+        "region": "us-west-2",
+        "period": 300,
+        "stat": "Sum",
+        "metrics": [
+          ["HoorayRelay/Ingestion", "webhook.enqueue.failure.count", "environment", "dev", "status_code", "500", { "label": "Enqueue failures", "color": "#d62728" }]
+        ]
+      }
+    },
+    {
+      "type": "metric",
+      "x": 0,
+      "y": 12,
+      "width": 12,
+      "height": 6,
+      "properties": {
+        "title": "Config API — Create & Get (5m Sum)",
+        "view": "timeSeries",
+        "stacked": false,
+        "region": "us-west-2",
+        "period": 300,
+        "stat": "Sum",
+        "metrics": [
+          ["HoorayRelay/Ingestion", "webhook.config.create.count", "environment", "dev", "status_code", "201", { "label": "Config created (201)" }],
+          ["HoorayRelay/Ingestion", "webhook.config.get.count",    "environment", "dev", "status_code", "200", { "label": "Config fetched (200)" }],
+          ["HoorayRelay/Ingestion", "webhook.config.get.count",    "environment", "dev", "status_code", "404", { "label": "Config not found (404)", "color": "#ff7f0e" }]
+        ]
+      }
+    },
+    {
+      "type": "metric",
+      "x": 12,
+      "y": 12,
+      "width": 12,
+      "height": 6,
+      "properties": {
+        "title": "Lambda — Ingestion Error Rate (5m)",
+        "view": "timeSeries",
+        "stacked": false,
+        "region": "us-west-2",
+        "period": 300,
+        "stat": "Sum",
+        "metrics": [
+          ["AWS/Lambda", "Errors",   "FunctionName", "IngestionFunction-dev", { "label": "Lambda errors",   "color": "#d62728" }],
+          ["AWS/Lambda", "Throttles","FunctionName", "IngestionFunction-dev", { "label": "Lambda throttles","color": "#ff7f0e" }],
+          ["AWS/Lambda", "Invocations","FunctionName","IngestionFunction-dev",{ "label": "Invocations",     "color": "#1f77b4" }]
+        ]
+      }
+    },
+    {
+      "type": "metric",
+      "x": 0,
+      "y": 18,
+      "width": 12,
+      "height": 6,
+      "properties": {
+        "title": "Lambda — Ingestion Duration (ms)",
+        "view": "timeSeries",
+        "stacked": false,
+        "region": "us-west-2",
+        "period": 300,
+        "metrics": [
+          ["AWS/Lambda", "Duration", "FunctionName", "IngestionFunction-dev", { "stat": "p50",  "label": "p50" }],
+          [".",          ".",        ".",             ".",                      { "stat": "p95",  "label": "p95" }],
+          [".",          ".",        ".",             ".",                      { "stat": "p99",  "label": "p99" }]
+        ]
+      }
+    },
+    {
+      "type": "metric",
+      "x": 12,
+      "y": 18,
+      "width": 12,
+      "height": 6,
+      "properties": {
+        "title": "API Gateway — 4xx / 5xx Errors (5m Sum)",
+        "view": "timeSeries",
+        "stacked": false,
+        "region": "us-west-2",
+        "period": 300,
+        "stat": "Sum",
+        "metrics": [
+          ["AWS/ApiGateway", "4XXError", "ApiName", "hooray-dev", { "label": "4xx errors", "color": "#ff7f0e" }],
+          ["AWS/ApiGateway", "5XXError", "ApiName", "hooray-dev", { "label": "5xx errors", "color": "#d62728" }]
+        ]
+      }
+    }
+  ]
+}

--- a/template.yaml
+++ b/template.yaml
@@ -260,6 +260,68 @@ Resources:
       TreatMissingData: notBreaching
 
   # -------------------------------------------------------------------------
+  # CloudWatch Alarms: Ingestion Lambda  (Engineer 1 — Day 6)
+  # -------------------------------------------------------------------------
+
+  # Fires when ≥1 Lambda-level error occurs in any 5-minute window.
+  # Lambda errors = unhandled panics / out-of-memory / timeout.
+  IngestionErrorRateAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "hooray-relay-ingestion-errors-${Environment}"
+      AlarmDescription: "Ingestion Lambda reported errors — check CloudWatch Logs"
+      Namespace: AWS/Lambda
+      MetricName: Errors
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref IngestionFunction
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  # Fires when the custom SQS enqueue failure metric is ≥1 in any 5-minute window.
+  # This detects events persisted to DynamoDB but never enqueued — orphaned events.
+  IngestionEnqueueFailureAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "hooray-relay-ingestion-enqueue-failure-${Environment}"
+      AlarmDescription: "Ingestion Lambda failed to enqueue event on SQS — orphaned events possible"
+      Namespace: HoorayRelay/Ingestion
+      MetricName: webhook.enqueue.failure.count
+      Dimensions:
+        - Name: environment
+          Value: !Ref Environment
+        - Name: status_code
+          Value: "500"
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  # Fires when ingestion p95 latency exceeds 2 000 ms over a 5-minute window.
+  IngestionLatencyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "hooray-relay-ingestion-latency-${Environment}"
+      AlarmDescription: "Ingestion Lambda p95 latency > 2 000 ms — possible DynamoDB or SQS slowdown"
+      Namespace: AWS/Lambda
+      MetricName: Duration
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref IngestionFunction
+      ExtendedStatistic: p95
+      Period: 300
+      EvaluationPeriods: 2
+      Threshold: 2000
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  # -------------------------------------------------------------------------
   # Lambda: Ingestion (Engineer 1)
   # Placeholder — binary will be provided by `cargo lambda build`
   # -------------------------------------------------------------------------


### PR DESCRIPTION
The ingestion pipeline was previously a black box — requests went in, events ended up in DynamoDB and SQS, but there was no visibility into what was happening at runtime. This PR fixes that.

What was added
The core of the work is a new [Observability](vscode-file://vscode-app/private/var/folders/pj/nrbn5v_16x79vwkr5sqxlpjr0000gn/T/AppTranslocation/A39A2291-19AA-43FC-90E9-DA821B9A5002/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) struct in [observability.rs](vscode-file://vscode-app/private/var/folders/pj/nrbn5v_16x79vwkr5sqxlpjr0000gn/T/AppTranslocation/A39A2291-19AA-43FC-90E9-DA821B9A5002/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html). It uses CloudWatch Embedded Metric Format (EMF), which means metrics are just JSON log lines — no SDK calls on the hot path, no agent to manage. CloudWatch Logs picks them up automatically and extracts them into real CloudWatch Metrics.

The struct is built once at Lambda cold-start and dropped into AppState alongside the AWS clients. Every handler now captures a [std::time::Instant](vscode-file://vscode-app/private/var/folders/pj/nrbn5v_16x79vwkr5sqxlpjr0000gn/T/AppTranslocation/A39A2291-19AA-43FC-90E9-DA821B9A5002/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) at entry and calls an emit_* helper on the way out, once the status code is known.

Six metrics are tracked across all endpoints:

Receive count & latency (p50/p95/p99) on every POST /webhooks/receive
Idempotency duplicates when a replay is detected
SQS enqueue failures when the queue write fails
Config create & get counts on the config CRUD endpoints
Each metric is emitted twice — once with a [customer_id](vscode-file://vscode-app/private/var/folders/pj/nrbn5v_16x79vwkr5sqxlpjr0000gn/T/AppTranslocation/A39A2291-19AA-43FC-90E9-DA821B9A5002/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) dimension for per-customer debugging, and once without for fleet-wide aggregation.

A new CloudWatch dashboard ([ingestion-dashboard.json](vscode-file://vscode-app/private/var/folders/pj/nrbn5v_16x79vwkr5sqxlpjr0000gn/T/AppTranslocation/A39A2291-19AA-43FC-90E9-DA821B9A5002/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)) pulls all of this together into 8 widgets: receive rate by status code, latency percentiles, idempotency hit rate, enqueue failures, config API counts, Lambda error rate, Lambda duration, and API Gateway error counts.

On the infrastructure side, [template.yaml](vscode-file://vscode-app/private/var/folders/pj/nrbn5v_16x79vwkr5sqxlpjr0000gn/T/AppTranslocation/A39A2291-19AA-43FC-90E9-DA821B9A5002/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) got the ENVIRONMENT / METRIC_NAMESPACE env vars, a cloudwatch:PutMetricData IAM statement, and CloudWatch alarms for error rate thresholds.

Finally, [README.md](vscode-file://vscode-app/private/var/folders/pj/nrbn5v_16x79vwkr5sqxlpjr0000gn/T/AppTranslocation/A39A2291-19AA-43FC-90E9-DA821B9A5002/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) has a full Day 6 engineering log section (§13), the summary table and roadmap are updated, and [README.md](vscode-file://vscode-app/private/var/folders/pj/nrbn5v_16x79vwkr5sqxlpjr0000gn/T/AppTranslocation/A39A2291-19AA-43FC-90E9-DA821B9A5002/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) now covers both the ingestion and worker dashboards instead of just the worker.
