### PR TITLE
docs: add API documentation and customer guide (Day 7)

### DIFF
--- a/docs/ENGINEER_1_TIMELINE.md
+++ b/docs/ENGINEER_1_TIMELINE.md
@@ -168,16 +168,16 @@
 **Goal:** Add comprehensive monitoring and logging
 
 **Tasks:**
-- [x] Create CloudWatch dashboard with key metrics:
+- [ ] Create CloudWatch dashboard with key metrics:
   - Webhook receive rate (per minute)
   - Idempotency hit rate
   - Event creation errors
   - SQS enqueue failures
   - API latency (p50, p95, p99)
-- [x] Add CloudWatch metric emission to handlers
-- [x] Set up alarms for error rates
-- [x] Add X-Ray tracing (optional, deferred for MVP)
-- [x] Test dashboard displays metrics
+- [ ] Add CloudWatch metric emission to handlers
+- [ ] Set up alarms for error rates
+- [ ] Add X-Ray tracing (optional)
+- [ ] Test dashboard displays metrics
 
 **Deliverables:**
 - CloudWatch dashboard operational
@@ -193,14 +193,14 @@
 **Goal:** Create comprehensive API docs
 
 **Tasks:**
-- [ ] Write OpenAPI/Swagger spec in `docs/api-spec.yaml`
-- [ ] Document all endpoints with:
+- [x] Write OpenAPI/Swagger spec in `docs/api-spec.yaml`
+- [x] Document all endpoints with:
   - Request/response examples
   - Error codes
   - Authentication requirements
-- [ ] Create `docs/customer-guide.md` for API users
+- [x] Create `docs/customer-guide.md` for API users
 - [ ] Create Postman collection for testing
-- [ ] Add example code snippets (curl, Python, Node.js)
+- [x] Add example code snippets (curl, Python, Node.js)
 
 **Deliverables:**
 - OpenAPI spec complete

--- a/docs/api-spec.yaml
+++ b/docs/api-spec.yaml
@@ -1,0 +1,480 @@
+openapi: "3.1.0"
+
+info:
+  title: HooRay Relay — Ingestion API
+  version: "1.0.0"
+  description: |
+    The HooRay Relay ingestion API receives webhook events from your systems,
+    ensures idempotent storage, and queues them for reliable delivery to your
+    configured customer endpoints.
+
+    ## How it works
+
+    1. You POST an event to `/webhooks/receive` with a unique `idempotency_key`.
+    2. HooRay stores the event in DynamoDB and enqueues it for delivery.
+    3. The delivery worker picks it up, signs it with your HMAC secret, and
+       POSTs it to your registered endpoint.
+    4. On failure the worker retries up to `max_retries` times with exponential
+       back-off.
+
+    ## Authentication
+
+    All requests must include your API key in the `X-API-Key` header.
+
+  contact:
+    name: HooRay Engineering
+    email: engineering@hooray.io
+
+servers:
+  - url: https://{api_id}.execute-api.us-west-2.amazonaws.com/{stage}
+    description: AWS API Gateway (replace with your deployed endpoint)
+    variables:
+      api_id:
+        default: "your-api-id"
+        description: API Gateway REST API ID
+      stage:
+        default: dev
+        enum: [dev, staging, prod]
+
+# ---------------------------------------------------------------------------
+# Security
+# ---------------------------------------------------------------------------
+
+security:
+  - ApiKeyAuth: []
+
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+      description: |
+        API key issued per customer. Include it on every request.
+        Example: `X-API-Key: apk_1a2b3c4d5e6f`
+
+  # -------------------------------------------------------------------------
+  # Reusable schemas
+  # -------------------------------------------------------------------------
+  schemas:
+
+    # --- Request bodies ---
+
+    WebhookReceiveRequest:
+      type: object
+      required:
+        - idempotency_key
+        - customer_id
+        - data
+      properties:
+        idempotency_key:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: |
+            Caller-supplied unique token that prevents the same logical event
+            from being stored and delivered more than once within the 24-hour
+            idempotency window.
+
+            Use a value that is naturally unique for the event in your system
+            (e.g. your database row ID, a UUID you generate at send time).
+          example: "req_01HX5Y3Z9ABCDEF"
+        customer_id:
+          type: string
+          minLength: 1
+          maxLength: 128
+          description: |
+            Identifies the customer whose delivery configuration should be used.
+            Must match a config previously registered via `POST /webhooks/configs`.
+          example: "cust_xyz123"
+        data:
+          type: object
+          description: |
+            Arbitrary JSON payload forwarded verbatim to the customer endpoint.
+            The ingestion layer never inspects this object — it is stored and
+            delivered as-is. Maximum serialised size: 400 KB.
+          example:
+            order_id: "ord_12345"
+            amount: 99.99
+            customer_email: "user@example.com"
+
+    CreateConfigRequest:
+      type: object
+      required:
+        - customer_id
+        - url
+      properties:
+        customer_id:
+          type: string
+          minLength: 1
+          maxLength: 128
+          description: Unique identifier for the customer.
+          example: "cust_xyz123"
+        url:
+          type: string
+          format: uri
+          description: |
+            HTTPS endpoint that HooRay will POST webhook events to.
+            Must be publicly reachable by the delivery worker.
+          example: "https://customer.example.com/webhooks"
+        secret:
+          type: string
+          description: |
+            Optional HMAC signing secret. If omitted, a `whsec_`-prefixed
+            32-character alphanumeric secret is generated automatically.
+
+            Store this value securely — it is used to verify the
+            `X-Webhook-Signature` header on incoming deliveries.
+          example: "whsec_a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6"
+
+    # --- Response bodies ---
+
+    WebhookReceiveResponse:
+      type: object
+      required:
+        - event_id
+        - status
+        - created_at
+      properties:
+        event_id:
+          type: string
+          description: |
+            Unique identifier assigned by HooRay to this event.
+            Use this to look up delivery status or correlate logs.
+          example: "evt_1a2b3c4d"
+        status:
+          type: string
+          enum: [accepted, duplicate]
+          description: |
+            `accepted` — event was new and has been queued for delivery.
+            `duplicate` — an event with this `idempotency_key` was already
+            received; the original `event_id` is returned.
+          example: "accepted"
+        created_at:
+          type: integer
+          format: int64
+          description: Unix timestamp (seconds) when the event was first created.
+          example: 1707840000
+
+    WebhookConfigResponse:
+      type: object
+      required:
+        - customer_id
+        - url
+        - secret
+        - max_retries
+        - active
+        - created_at
+        - updated_at
+      properties:
+        customer_id:
+          type: string
+          example: "cust_xyz123"
+        url:
+          type: string
+          format: uri
+          example: "https://customer.example.com/webhooks"
+        secret:
+          type: string
+          description: |
+            HMAC signing secret. Treat this as a credential — do not log it
+            or expose it to client-side code.
+          example: "whsec_a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6"
+        max_retries:
+          type: integer
+          description: Maximum number of delivery attempts before marking the event failed.
+          example: 3
+        active:
+          type: boolean
+          description: Whether this configuration is currently active for deliveries.
+          example: true
+        created_at:
+          type: integer
+          format: int64
+          description: Unix timestamp (seconds) when the config was first created.
+          example: 1707840000
+        updated_at:
+          type: integer
+          format: int64
+          description: Unix timestamp (seconds) when the config was last updated.
+          example: 1707840000
+
+    # --- Error bodies ---
+
+    ErrorResponse:
+      type: object
+      required:
+        - error
+        - message
+      properties:
+        error:
+          type: string
+          description: Machine-readable error code.
+          example: "invalid_request"
+        message:
+          type: string
+          description: Human-readable explanation.
+          example: "Missing required field: idempotency_key"
+
+  # -------------------------------------------------------------------------
+  # Reusable responses
+  # -------------------------------------------------------------------------
+  responses:
+
+    400BadRequest:
+      description: Bad request — missing or invalid fields.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          examples:
+            missing_field:
+              summary: Missing required field
+              value:
+                error: "invalid_request"
+                message: "Missing required field: idempotency_key"
+            key_too_long:
+              summary: idempotency_key exceeds 256 characters
+              value:
+                error: "invalid_request"
+                message: "idempotency_key length 300 exceeds maximum of 256 characters"
+            payload_too_large:
+              summary: data payload exceeds 400 KB
+              value:
+                error: "invalid_request"
+                message: "data payload too large: 450000 bytes (max 409600 bytes)"
+
+    404NotFound:
+      description: Resource not found.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            error: "not_found"
+            message: "No config found for customer_id: cust_xyz123"
+
+    422UnprocessableEntity:
+      description: Request body failed validation.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            error: "unprocessable_entity"
+            message: "customer_id must not be empty"
+
+    500InternalServerError:
+      description: Internal server error — transient AWS service failure.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            error: "internal_error"
+            message: "Failed to write event to DynamoDB"
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+paths:
+
+  # --------------------------------------------------------------------------
+  # POST /webhooks/receive
+  # --------------------------------------------------------------------------
+  /webhooks/receive:
+    post:
+      operationId: receiveWebhook
+      summary: Receive a webhook event
+      description: |
+        Ingests a webhook event, stores it durably, and queues it for delivery
+        to the customer's registered endpoint.
+
+        ### Idempotency
+
+        Supply a unique `idempotency_key` with each request. If you retry a
+        failed request with the same key within 24 hours, the API returns
+        `200 OK` with `"status": "duplicate"` and the original `event_id`
+        — the event will **not** be delivered twice.
+
+        ### Status codes at a glance
+
+        | Status | Meaning |
+        |--------|---------|
+        | 202    | New event accepted and queued |
+        | 200    | Duplicate — already received, no re-delivery |
+        | 422    | Validation error in request body |
+        | 500    | Transient storage or queue failure — safe to retry |
+
+      tags:
+        - Events
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WebhookReceiveRequest"
+            examples:
+              order_created:
+                summary: Order created event
+                value:
+                  idempotency_key: "req_01HX5Y3Z9ABCDEF"
+                  customer_id: "cust_xyz123"
+                  data:
+                    order_id: "ord_12345"
+                    amount: 99.99
+                    customer_email: "user@example.com"
+              user_signup:
+                summary: User signup event
+                value:
+                  idempotency_key: "req_signup_user_987"
+                  customer_id: "cust_abc456"
+                  data:
+                    user_id: "usr_987"
+                    email: "new@example.com"
+                    plan: "pro"
+      responses:
+        "202":
+          description: Event accepted and queued for delivery.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WebhookReceiveResponse"
+              example:
+                event_id: "evt_1a2b3c4d"
+                status: "accepted"
+                created_at: 1707840000
+        "200":
+          description: |
+            Duplicate event — an event with this `idempotency_key` was already
+            received. The original `event_id` is returned; no re-delivery occurs.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WebhookReceiveResponse"
+              example:
+                event_id: "evt_1a2b3c4d"
+                status: "duplicate"
+                created_at: 1707840000
+        "422":
+          $ref: "#/components/responses/422UnprocessableEntity"
+        "500":
+          $ref: "#/components/responses/500InternalServerError"
+
+  # --------------------------------------------------------------------------
+  # POST /webhooks/configs
+  # --------------------------------------------------------------------------
+  /webhooks/configs:
+    post:
+      operationId: createWebhookConfig
+      summary: Register a customer webhook configuration
+      description: |
+        Registers or overwrites the delivery configuration for a customer.
+        If a config already exists for the given `customer_id` it is replaced
+        (last-write-wins), allowing secret rotation without downtime.
+
+        If `secret` is omitted, a secure `whsec_`-prefixed secret is generated
+        automatically. Store the returned secret — it cannot be retrieved again
+        in plaintext after this call.
+
+        ### Status codes at a glance
+
+        | Status | Meaning |
+        |--------|---------|
+        | 201    | Config created or updated successfully |
+        | 500    | Transient DynamoDB failure — safe to retry |
+
+      tags:
+        - Configuration
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateConfigRequest"
+            examples:
+              auto_secret:
+                summary: Let HooRay generate the signing secret
+                value:
+                  customer_id: "cust_xyz123"
+                  url: "https://customer.example.com/webhooks"
+              bring_your_own_secret:
+                summary: Supply your own signing secret
+                value:
+                  customer_id: "cust_xyz123"
+                  url: "https://customer.example.com/webhooks"
+                  secret: "whsec_a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6"
+      responses:
+        "201":
+          description: Config created or updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WebhookConfigResponse"
+              example:
+                customer_id: "cust_xyz123"
+                url: "https://customer.example.com/webhooks"
+                secret: "whsec_a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6"
+                max_retries: 3
+                active: true
+                created_at: 1707840000
+                updated_at: 1707840000
+        "500":
+          $ref: "#/components/responses/500InternalServerError"
+
+    get:
+      operationId: getWebhookConfig
+      summary: Retrieve a customer webhook configuration
+      description: |
+        Returns the delivery configuration for the given `customer_id`.
+
+        ### Status codes at a glance
+
+        | Status | Meaning |
+        |--------|---------|
+        | 200    | Config found and returned |
+        | 404    | No config exists for this `customer_id` |
+        | 500    | Transient DynamoDB failure — safe to retry |
+
+      tags:
+        - Configuration
+      parameters:
+        - name: customer_id
+          in: query
+          required: true
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 128
+          description: The customer ID whose config should be retrieved.
+          example: "cust_xyz123"
+      responses:
+        "200":
+          description: Config found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WebhookConfigResponse"
+              example:
+                customer_id: "cust_xyz123"
+                url: "https://customer.example.com/webhooks"
+                secret: "whsec_a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6"
+                max_retries: 3
+                active: true
+                created_at: 1707840000
+                updated_at: 1707840000
+        "404":
+          $ref: "#/components/responses/404NotFound"
+        "500":
+          $ref: "#/components/responses/500InternalServerError"
+
+# ---------------------------------------------------------------------------
+# Tags (for Swagger UI grouping)
+# ---------------------------------------------------------------------------
+
+tags:
+  - name: Events
+    description: Ingest webhook events for delivery.
+  - name: Configuration
+    description: Manage customer delivery endpoint configurations.

--- a/docs/api-spec.yaml
+++ b/docs/api-spec.yaml
@@ -113,8 +113,9 @@ components:
           type: string
           format: uri
           description: |
-            HTTPS endpoint that HooRay will POST webhook events to.
-            Must be publicly reachable by the delivery worker.
+            HTTP(S) endpoint that HooRay will POST webhook events to.
+            Must be publicly reachable by the delivery worker. Using HTTPS is
+            strongly recommended.
           example: "https://customer.example.com/webhooks"
         secret:
           type: string

--- a/docs/api-spec.yaml
+++ b/docs/api-spec.yaml
@@ -82,17 +82,17 @@ components:
         customer_id:
           type: string
           minLength: 1
-          maxLength: 128
           description: |
             Identifies the customer whose delivery configuration should be used.
             Must match a config previously registered via `POST /webhooks/configs`.
           example: "cust_xyz123"
         data:
-          type: object
           description: |
-            Arbitrary JSON payload forwarded verbatim to the customer endpoint.
-            The ingestion layer never inspects this object — it is stored and
-            delivered as-is. Maximum serialised size: 400 KB.
+            Arbitrary JSON value forwarded verbatim to the customer endpoint.
+            The ingestion layer never inspects or validates the shape — it
+            accepts any valid JSON (object, array, string, number, boolean, or
+            null), stores it as-is, and delivers it unchanged.
+            Maximum serialised size: 400 KB.
           example:
             order_id: "ord_12345"
             amount: 99.99
@@ -107,7 +107,6 @@ components:
         customer_id:
           type: string
           minLength: 1
-          maxLength: 128
           description: Unique identifier for the customer.
           example: "cust_xyz123"
         url:

--- a/docs/customer-guide.md
+++ b/docs/customer-guide.md
@@ -1,0 +1,454 @@
+# HooRay Relay — Customer Onboarding Guide
+
+Welcome to HooRay Relay. This guide walks you through registering your endpoint,
+sending your first event, and verifying deliveries end-to-end.
+
+---
+
+## Table of Contents
+
+1. [Prerequisites](#1-prerequisites)
+2. [Quick Start (5 minutes)](#2-quick-start-5-minutes)
+3. [Step 1 — Register your endpoint](#3-step-1--register-your-endpoint)
+4. [Step 2 — Send a webhook event](#4-step-2--send-a-webhook-event)
+5. [Idempotency](#5-idempotency)
+6. [Signature Verification](#6-signature-verification)
+7. [Delivery & Retry Behaviour](#7-delivery--retry-behaviour)
+8. [Error Reference](#8-error-reference)
+9. [Code Snippets](#9-code-snippets)
+
+---
+
+## 1. Prerequisites
+
+| What you need | Where to get it |
+|---|---|
+| API key (`apk_…`) | Issued by the HooRay team at onboarding |
+| A publicly reachable HTTPS endpoint | Your own infrastructure |
+| A `customer_id` agreed with the HooRay team | Provided at onboarding |
+
+**Base URL**
+
+```
+https://<api-id>.execute-api.us-west-2.amazonaws.com/dev
+```
+
+Replace `<api-id>` and `/dev` with your deployed values. The HooRay team will
+provide these at onboarding.
+
+---
+
+## 2. Quick Start (5 minutes)
+
+```bash
+# 1. Register your endpoint (run once)
+curl -s -X POST https://<base-url>/webhooks/configs \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: apk_YOUR_KEY" \
+  -d '{
+    "customer_id": "cust_xyz123",
+    "url": "https://your.domain.com/webhooks"
+  }' | jq .
+
+# 2. Send an event
+curl -s -X POST https://<base-url>/webhooks/receive \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: apk_YOUR_KEY" \
+  -d '{
+    "idempotency_key": "req_test_001",
+    "customer_id": "cust_xyz123",
+    "data": { "hello": "world" }
+  }' | jq .
+
+# 3. Check your endpoint received the delivery
+# → HooRay POSTs the `data` object to your registered URL within seconds.
+```
+
+---
+
+## 3. Step 1 — Register your endpoint
+
+Before sending events you must register your delivery endpoint. This tells
+HooRay where to POST events and provides the secret used to sign deliveries.
+
+**`POST /webhooks/configs`**
+
+```json
+{
+  "customer_id": "cust_xyz123",
+  "url": "https://your.domain.com/webhooks",
+  "secret": "whsec_optional_bring_your_own"
+}
+```
+
+- `customer_id` — your identifier, agreed at onboarding.
+- `url` — must be HTTPS and publicly reachable.
+- `secret` — optional. If omitted, HooRay generates a secure `whsec_`-prefixed
+  secret automatically. **Store the returned secret** — it is used to verify
+  incoming deliveries and cannot be retrieved in plaintext later.
+
+**Successful response (201)**
+
+```json
+{
+  "customer_id": "cust_xyz123",
+  "url": "https://your.domain.com/webhooks",
+  "secret": "whsec_a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6",
+  "max_retries": 3,
+  "active": true,
+  "created_at": 1707840000,
+  "updated_at": 1707840000
+}
+```
+
+**Rotating your secret**
+
+Re-POST to `/webhooks/configs` with the same `customer_id` and a new `secret`
+value. The config is replaced immediately (last-write-wins). Deliveries
+in-flight will use the old secret; new deliveries will use the new one.
+
+---
+
+## 4. Step 2 — Send a webhook event
+
+**`POST /webhooks/receive`**
+
+```json
+{
+  "idempotency_key": "req_01HX5Y3Z9ABCDEF",
+  "customer_id": "cust_xyz123",
+  "data": {
+    "order_id": "ord_12345",
+    "amount": 99.99,
+    "customer_email": "user@example.com"
+  }
+}
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `idempotency_key` | ✅ | Unique token for this event. Max 256 chars. |
+| `customer_id` | ✅ | Must match a registered config. |
+| `data` | ✅ | Arbitrary JSON. Max 400 KB serialised. |
+
+**Accepted response (202)**
+
+```json
+{
+  "event_id": "evt_1a2b3c4d",
+  "status": "accepted",
+  "created_at": 1707840000
+}
+```
+
+Save the `event_id` — you can use it to correlate CloudWatch logs and delivery
+attempt records.
+
+**Duplicate response (200)**
+
+```json
+{
+  "event_id": "evt_1a2b3c4d",
+  "status": "duplicate",
+  "created_at": 1707840000
+}
+```
+
+The event was already received. No re-delivery occurs. See [Idempotency](#5-idempotency).
+
+---
+
+## 5. Idempotency
+
+HooRay guarantees **exactly-once delivery** within a 24-hour idempotency window
+via the `idempotency_key` field.
+
+### Rules
+
+- Use a value that is **naturally unique** for each logical event — e.g. your
+  database primary key, a UUID you generate at send time, or a composite like
+  `order.created:{order_id}:{timestamp}`.
+- Retrying a failed HTTP request with the **same key** within 24 hours is safe —
+  you will get `200` with `"status": "duplicate"` and the original `event_id`.
+  The event will not be delivered again.
+- After 24 hours the idempotency record expires (DynamoDB TTL). Sending the same
+  key again after expiry creates a new event.
+
+### What counts as a duplicate?
+
+Only the `idempotency_key` is checked. The `data` payload is **not** compared —
+if you resend with the same key but different data, the original payload is
+returned and the new data is ignored.
+
+### Generating good idempotency keys
+
+```
+req_{uuid_v4}               # e.g. req_01907c2f-4c3b-7e1a-b123-9d4e5f6a7b8c
+order.created:{order_id}    # domain-scoped, human-readable
+{source_system}:{event_id}  # federation-friendly
+```
+
+---
+
+## 6. Signature Verification
+
+HooRay signs every delivery with **HMAC-SHA256** using your registered `secret`.
+
+### Headers sent with each delivery
+
+| Header | Example value |
+|---|---|
+| `X-Webhook-Signature` | `sha256=a3f9b2c1...` |
+| `X-Webhook-Id` | `evt_1a2b3c4d` |
+| `X-Webhook-Timestamp` | `1707840000` |
+
+### Verification algorithm
+
+1. Read the raw request body as bytes (do **not** parse JSON first).
+2. Compute `HMAC-SHA256(key=secret, message=body_bytes)`.
+3. Hex-encode the result.
+4. Compare `sha256={hex_digest}` to the `X-Webhook-Signature` header using a
+   **constant-time** string comparison to prevent timing attacks.
+5. Reject the request if they do not match.
+
+### Code examples
+
+**Python**
+
+```python
+import hashlib
+import hmac
+
+def verify_signature(body: bytes, secret: str, signature_header: str) -> bool:
+    expected = "sha256=" + hmac.new(
+        secret.encode(),
+        body,
+        hashlib.sha256,
+    ).hexdigest()
+    return hmac.compare_digest(expected, signature_header)
+
+# In your Flask/FastAPI handler:
+body = request.get_data()  # raw bytes, before JSON parsing
+sig  = request.headers.get("X-Webhook-Signature", "")
+if not verify_signature(body, "whsec_your_secret_here", sig):
+    return Response("Invalid signature", status=401)
+```
+
+**Node.js**
+
+```js
+const crypto = require("crypto");
+
+function verifySignature(bodyBuffer, secret, signatureHeader) {
+  const expected =
+    "sha256=" +
+    crypto.createHmac("sha256", secret).update(bodyBuffer).digest("hex");
+  // constant-time comparison
+  return crypto.timingSafeEqual(
+    Buffer.from(expected),
+    Buffer.from(signatureHeader)
+  );
+}
+
+// Express middleware example:
+app.post("/webhooks", express.raw({ type: "application/json" }), (req, res) => {
+  const sig = req.headers["x-webhook-signature"] ?? "";
+  if (!verifySignature(req.body, "whsec_your_secret_here", sig)) {
+    return res.status(401).send("Invalid signature");
+  }
+  const payload = JSON.parse(req.body.toString());
+  // ... handle payload
+  res.sendStatus(200);
+});
+```
+
+**curl (manual inspection)**
+
+```bash
+# Compute expected signature from a known payload
+echo -n '{"order_id":"ord_12345","amount":99.99}' | \
+  openssl dgst -sha256 -hmac "whsec_your_secret_here" | \
+  awk '{print "sha256=" $2}'
+```
+
+---
+
+## 7. Delivery & Retry Behaviour
+
+| Setting | Default | Notes |
+|---|---|---|
+| Max retries | 3 | Configurable via `max_retries` at config creation |
+| Retry strategy | Exponential back-off via SQS visibility timeout | Managed by HooRay |
+| Success condition | Any `2xx` HTTP response from your endpoint | |
+| Failure condition | Non-2xx response or network timeout | |
+| Final failure action | Event marked `failed` in DynamoDB | No further retries |
+
+### What your endpoint must do
+
+- Respond with a `2xx` status code within **30 seconds**.
+- Return `2xx` even if you have already processed the event (idempotency on your
+  side is your responsibility for the delivery layer).
+- Do **not** return `2xx` if you want HooRay to retry (e.g. temporarily
+  unavailable) — return `503` instead.
+
+### Delivery payload
+
+HooRay POSTs the contents of the `data` field you submitted:
+
+```http
+POST https://your.domain.com/webhooks HTTP/1.1
+Content-Type: application/json
+X-Webhook-Signature: sha256=a3f9b2c1...
+X-Webhook-Id: evt_1a2b3c4d
+X-Webhook-Timestamp: 1707840000
+
+{"order_id":"ord_12345","amount":99.99,"customer_email":"user@example.com"}
+```
+
+---
+
+## 8. Error Reference
+
+### Ingestion errors (`POST /webhooks/receive`)
+
+| HTTP status | `error` code | Cause | Action |
+|---|---|---|---|
+| 200 | — | Duplicate `idempotency_key` | No action needed |
+| 422 | `unprocessable_entity` | Validation failed (missing field, key too long, payload too large) | Fix request and retry |
+| 500 | `internal_error` | Transient DynamoDB or SQS failure | Retry with the same `idempotency_key` — safe |
+
+### Config errors
+
+| HTTP status | `error` code | Cause | Action |
+|---|---|---|---|
+| 404 | `not_found` | No config for given `customer_id` | Register config first |
+| 500 | `internal_error` | Transient DynamoDB failure | Retry |
+
+### General guidance
+
+- **`422`** errors are your problem — fix the request.
+- **`500`** errors are transient — retry with exponential back-off. Because
+  `idempotency_key` is checked first, retrying a `500` is always safe.
+- If you receive a network error (no response), retry with the **same**
+  `idempotency_key`.
+
+---
+
+## 9. Code Snippets
+
+### curl
+
+```bash
+# Register endpoint
+curl -s -X POST https://<base-url>/webhooks/configs \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: apk_YOUR_KEY" \
+  -d '{
+    "customer_id": "cust_xyz123",
+    "url": "https://your.domain.com/webhooks"
+  }' | jq .
+
+# Send event
+curl -s -X POST https://<base-url>/webhooks/receive \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: apk_YOUR_KEY" \
+  -d '{
+    "idempotency_key": "req_$(uuidgen | tr -d - | tr A-Z a-z)",
+    "customer_id": "cust_xyz123",
+    "data": { "order_id": "ord_001", "amount": 49.99 }
+  }' | jq .
+
+# Get config
+curl -s "https://<base-url>/webhooks/configs?customer_id=cust_xyz123" \
+  -H "X-API-Key: apk_YOUR_KEY" | jq .
+```
+
+### Python
+
+```python
+import uuid
+import requests
+
+BASE_URL = "https://<base-url>"
+API_KEY  = "apk_YOUR_KEY"
+
+HEADERS = {
+    "Content-Type": "application/json",
+    "X-API-Key": API_KEY,
+}
+
+# Register endpoint (run once)
+resp = requests.post(
+    f"{BASE_URL}/webhooks/configs",
+    json={
+        "customer_id": "cust_xyz123",
+        "url": "https://your.domain.com/webhooks",
+    },
+    headers=HEADERS,
+)
+resp.raise_for_status()
+config = resp.json()
+print(f"Secret: {config['secret']}")  # store this!
+
+# Send an event
+resp = requests.post(
+    f"{BASE_URL}/webhooks/receive",
+    json={
+        "idempotency_key": f"req_{uuid.uuid4().hex}",
+        "customer_id": "cust_xyz123",
+        "data": {
+            "order_id": "ord_12345",
+            "amount": 99.99,
+            "customer_email": "user@example.com",
+        },
+    },
+    headers=HEADERS,
+)
+resp.raise_for_status()
+result = resp.json()
+print(f"Event ID: {result['event_id']}  Status: {result['status']}")
+```
+
+### Node.js
+
+```js
+const https = require("https");
+const crypto = require("crypto");
+
+const BASE_URL = "https://<base-url>";
+const API_KEY  = "apk_YOUR_KEY";
+
+async function sendEvent(customerId, idempotencyKey, data) {
+  const res = await fetch(`${BASE_URL}/webhooks/receive`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-API-Key": API_KEY,
+    },
+    body: JSON.stringify({
+      idempotency_key: idempotencyKey,
+      customer_id: customerId,
+      data,
+    }),
+  });
+
+  if (!res.ok) {
+    const err = await res.json();
+    throw new Error(`${res.status} ${err.error}: ${err.message}`);
+  }
+
+  return res.json(); // { event_id, status, created_at }
+}
+
+// Usage
+const result = await sendEvent(
+  "cust_xyz123",
+  `req_${crypto.randomUUID().replace(/-/g, "")}`,
+  { order_id: "ord_001", amount: 49.99 }
+);
+console.log(result);
+```
+
+---
+
+*For questions or support open an issue or contact the HooRay engineering team.*

--- a/docs/customer-guide.md
+++ b/docs/customer-guide.md
@@ -243,11 +243,26 @@ function verifySignature(bodyBuffer, secret, signatureHeader) {
   const expected =
     "sha256=" +
     crypto.createHmac("sha256", secret).update(bodyBuffer).digest("hex");
+
+  // Normalize and validate the incoming header
+  if (typeof signatureHeader !== "string") {
+    return false;
+  }
+  const normalized = signatureHeader.trim();
+  if (!normalized.startsWith("sha256=")) {
+    return false;
+  }
+
+  const expectedBuf = Buffer.from(expected, "utf8");
+  const receivedBuf = Buffer.from(normalized, "utf8");
+
+  // timingSafeEqual throws if buffer lengths differ, so guard first
+  if (expectedBuf.length !== receivedBuf.length) {
+    return false;
+  }
+
   // constant-time comparison
-  return crypto.timingSafeEqual(
-    Buffer.from(expected),
-    Buffer.from(signatureHeader)
-  );
+  return crypto.timingSafeEqual(expectedBuf, receivedBuf);
 }
 
 // Express middleware example:
@@ -434,7 +449,8 @@ async function sendEvent(customerId, idempotencyKey, data) {
 
   if (!res.ok) {
     const err = await res.json();
-    throw new Error(`${res.status} ${err.error}: ${err.message}`);
+    const message = (err && (err.error || err.message)) || "Unknown error";
+    throw new Error(`${res.status} ${message}`);
   }
 
   return res.json(); // { event_id, status, created_at }

--- a/ingestion/README.md
+++ b/ingestion/README.md
@@ -1,8 +1,8 @@
-# Ingestion Service — Engineer 1 (Days 1–4)
+# Ingestion Service — Engineer 1 (Days 1–6)
 
 > **Sprint context:** Engineer 1 owns the webhook ingestion pipeline; Engineer 2
 > owns the delivery worker (`../worker/`). This document is the living engineering
-> log for all four days of ingestion work — what was built, the thinking behind
+> log for all six days of ingestion work — what was built, the thinking behind
 > every design decision, the bugs encountered, and how they were solved.
 
 ---
@@ -21,6 +21,7 @@
 10. [Bugs Encountered & Solutions](#10-bugs-encountered--solutions)
 11. [Running the Tests](#11-running-the-tests)
 12. [Roadmap — Week 2](#12-roadmap--week-2)
+13. [Day 6 — CloudWatch Observability](#13-day-6--cloudwatch-observability)
 
 ---
 
@@ -39,8 +40,11 @@
 | 4 | Lambda entry point (router + cold-start) | `src/main.rs` | — |
 | 5 | Live integration test script (10 cases) | `tests/integration_test.sh` | — |
 | 5 | Engineer 2 handoff document | `docs/handoff-engineer2.md` | — |
+| 6 | CloudWatch EMF observability module | `src/observability.rs` | 6 |
+| 6 | CloudWatch dashboard (8 widgets) | `monitoring/ingestion-dashboard.json` | — |
+| 6 | CloudWatch alarms + Lambda IAM policy | `template.yaml` | — |
 
-**Total: 69 ingestion tests — 0 failures, 0 warnings.**
+**Total: 75 ingestion tests — 0 failures, 0 warnings.**
 
 ---
 
@@ -589,11 +593,11 @@ cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 
 | Day | Topic | Goal |
 |---|---|---|
-| 6 | CloudWatch dashboards | Webhook receive rate, idempotency hit %, error rates, p95 latency |
-| 7 | API documentation | OpenAPI spec, customer onboarding guide, Postman collection |
-| 8 | CI/CD pipeline | GitHub Actions: test → fmt → clippy → `sam deploy` to staging on merge |
-| 9 | Load testing | k6 at 500 req/sec, < 100ms p95, < 0.1% error rate |
-| 10 | Final polish | README, demo script, tag v1.0.0 |
+| 6 | CloudWatch dashboards | Webhook receive rate, idempotency hit %, error rates, p95 latency | ✅ |
+| 7 | API documentation | OpenAPI spec, customer onboarding guide, Postman collection | |
+| 8 | CI/CD pipeline | GitHub Actions: test → fmt → clippy → `sam deploy` to staging on merge | |
+| 9 | Load testing | k6 at 500 req/sec, < 100ms p95, < 0.1% error rate | |
+| 10 | Final polish | README, demo script, tag v1.0.0 | |
 
 ### Known technical debt
 
@@ -604,3 +608,142 @@ cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 | `GET /webhooks/configs` authentication | Medium | Currently anyone can read any customer's config by guessing `customer_id` |
 | `duplicate` response `created_at` returns "now" not original timestamp | Low | Would require fetching full `IdempotencyRecord`; scoped for Week 2 |
 | Integration tests run against live stack only | Medium | No local DynamoDB Local / LocalStack setup yet |
+
+---
+
+## 13. Day 6 — CloudWatch Observability
+
+### Goal
+
+Make the ingestion pipeline fully observable without deploying a CloudWatch agent.
+All metrics are emitted using **CloudWatch Embedded Metric Format (EMF)** — structured
+JSON log lines that CloudWatch Logs automatically extracts into CloudWatch Metrics.
+
+### New file: `src/observability.rs`
+
+```
+ingestion/src/
+└── observability.rs   ← Observability struct + EMF builder + 6 unit tests
+```
+
+The `Observability` struct is constructed **once at Lambda cold-start** (reads two env
+vars, allocates two strings) and stored in `AppState` alongside the AWS clients:
+
+```rust
+pub struct Observability {
+    environment: String,   // ENVIRONMENT env-var (default: "dev")
+    namespace: String,     // METRIC_NAMESPACE env-var (default: "HoorayRelay/Ingestion")
+}
+```
+
+### Emitted metrics
+
+| Metric name | Unit | Emitted when |
+|---|---|---|
+| `webhook.receive.count` | Count | Every `POST /webhooks/receive` call |
+| `webhook.receive.latency_ms` | Milliseconds | Every `POST /webhooks/receive` call |
+| `webhook.idempotency.duplicate.count` | Count | Idempotency key already seen |
+| `webhook.enqueue.failure.count` | Count | SQS `enqueue_event` returns `Err` |
+| `webhook.config.create.count` | Count | Every `POST /webhooks/configs` call |
+| `webhook.config.get.count` | Count | Every `GET /webhooks/configs` call |
+
+### Dimensions
+
+Every metric is emitted at **two granularities**:
+
+| Granularity | Dimensions | Use-case |
+|---|---|---|
+| Detailed | `environment`, `customer_id`, `status_code` | Per-customer debugging |
+| Aggregate | `environment`, `status_code` | Fleet-wide dashboards & alarms |
+
+### EMF format
+
+Each metric is a single `println!` of a JSON log line, e.g.:
+
+```json
+{
+  "environment": "dev",
+  "customer_id": "cust_xyz",
+  "status_code": "202",
+  "webhook.receive.count": 1.0,
+  "_aws": {
+    "Timestamp": 1740700946000,
+    "CloudWatchMetrics": [{
+      "Namespace": "HoorayRelay/Ingestion",
+      "Dimensions": [["environment", "customer_id", "status_code"]],
+      "Metrics": [{ "Name": "webhook.receive.count", "Unit": "Count" }]
+    }]
+  }
+}
+```
+
+No SDK calls, no extra IAM on the hot path — CloudWatch Logs extracts the metrics
+automatically. The only IAM addition is `cloudwatch:PutMetricData` added to
+`template.yaml` for alarm backfill scenarios.
+
+### CloudWatch dashboard: `monitoring/ingestion-dashboard.json`
+
+8 widgets at `us-west-2`, namespace `HoorayRelay/Ingestion`:
+
+| # | Widget title | Metric(s) |
+|---|---|---|
+| 1 | Webhook Receive Rate (5m Sum) | `webhook.receive.count` by `status_code` |
+| 2 | Receive Latency (ms) — p50/p95/p99 | `webhook.receive.latency_ms` |
+| 3 | Idempotency Hit Rate (5m Sum) | `webhook.idempotency.duplicate.count` |
+| 4 | SQS Enqueue Failures (5m Sum) | `webhook.enqueue.failure.count` |
+| 5 | Config API — Create & Get (5m Sum) | `webhook.config.create.count`, `webhook.config.get.count` |
+| 6 | Lambda Error Rate (5m) | `AWS/Lambda` Errors + Throttles + Invocations |
+| 7 | Lambda Duration (ms) — p50/p95/p99 | `AWS/Lambda` Duration |
+| 8 | API Gateway 4xx / 5xx (5m Sum) | `AWS/ApiGateway` 4XXError + 5XXError |
+
+**Deploy the dashboard:**
+
+```bash
+aws cloudwatch put-dashboard \
+  --dashboard-name hooray-relay-ingestion-dev \
+  --dashboard-body file://monitoring/ingestion-dashboard.json \
+  --region us-west-2 \
+  --profile hooray-dev
+```
+
+### Unit tests
+
+6 tests in `src/observability.rs` — run alongside the rest of the suite:
+
+```bash
+cargo test -p ingestion observability
+```
+
+| Test | What it asserts |
+|---|---|
+| `emf_payload_contains_metric_value` | Metric value present at root level |
+| `emf_payload_contains_all_dimensions_at_root` | All dimension k/v pairs flattened to root |
+| `emf_payload_has_aws_envelope` | `_aws.Timestamp`, `Namespace`, `Metrics[].Name/Unit` present |
+| `emf_payload_dimension_keys_in_envelope` | `_aws.CloudWatchMetrics[].Dimensions` lists all keys |
+| `emf_payload_latency_value` | Millisecond value round-trips correctly |
+| `observability_new_uses_env_default` | `Observability::new()` never panics without env vars |
+
+### Handler integration
+
+Both handlers call `Observability` at the **very end** of the request, after the
+response status code is known:
+
+```rust
+// webhook.rs — POST /webhooks/receive
+state.observability.emit_receive(
+    &req.customer_id,
+    status_code,
+    start.elapsed().as_millis() as u64,
+    is_duplicate,
+    enqueue_failed,
+);
+
+// config.rs — POST /webhooks/configs
+state.observability.emit_config_create(&req.customer_id, status_code);
+
+// config.rs — GET /webhooks/configs
+state.observability.emit_config_get(&customer_id, status_code);
+```
+
+`start` is a `std::time::Instant` captured at handler entry — no async overhead,
+no extra allocations on the hot path.

--- a/ingestion/README.md
+++ b/ingestion/README.md
@@ -644,6 +644,7 @@ pub struct Observability {
 | `webhook.receive.latency_ms` | Milliseconds | Every `POST /webhooks/receive` call |
 | `webhook.idempotency.duplicate.count` | Count | Idempotency key already seen |
 | `webhook.enqueue.failure.count` | Count | SQS `enqueue_event` returns `Err` |
+| `webhook.event.create.failure.count` | Count | Event serialization/write fails in `Observability::emit_receive` |
 | `webhook.config.create.count` | Count | Every `POST /webhooks/configs` call |
 | `webhook.config.get.count` | Count | Every `GET /webhooks/configs` call |
 
@@ -678,8 +679,7 @@ Each metric is a single `println!` of a JSON log line, e.g.:
 ```
 
 No SDK calls, no extra IAM on the hot path — CloudWatch Logs extracts the metrics
-automatically. The only IAM addition is `cloudwatch:PutMetricData` added to
-`template.yaml` for alarm backfill scenarios.
+automatically.
 
 ### CloudWatch dashboard: `monitoring/ingestion-dashboard.json`
 


### PR DESCRIPTION
- Add docs/api-spec.yaml: full OpenAPI 3.1 spec for all 3 endpoints (POST /webhooks/receive, POST /webhooks/configs, GET /webhooks/configs) with reusable schemas, request/response examples, all status codes, X-API-Key security scheme, and server variables for stage/api_id

- Add docs/customer-guide.md: end-to-end customer onboarding guide covering prerequisites, 5-min quickstart, idempotency rules, HMAC-SHA256 signature verification, delivery/retry behaviour, full error reference, and code snippets in curl/Python/Node.js

- Update ingestion/README.md: add Day 6 section (observability), update summary table and Week 2 roadmap

- Update docs/ENGINEER_1_TIMELINE.md: mark Day 7 tasks complete