### PR TITLE
worker+infra: persist breaker state and harden ECS deploy path

### DIFF
--- a/.samignore
+++ b/.samignore
@@ -1,0 +1,6 @@
+target/
+.git/
+.aws-sam/
+node_modules/
+**/*.log
+day6-observability-fail.log

--- a/docs/ENGINEER_2_TIMELINE.md
+++ b/docs/ENGINEER_2_TIMELINE.md
@@ -281,30 +281,45 @@
 
 ### Day 8: Error Handling & DLQ Processing
 
-**Goal:** Robust error handling and dead letter queue management
+**Goal:** Harden resilience path (error taxonomy + breaker behavior) and operationalize DLQ handling
 
-**Tasks:**
-- [ ] Improve error classification:
-  - Network errors (timeout, connection refused)
-  - HTTP errors (4xx vs 5xx)
-  - Service errors (config not found)
-- [ ] Create DLQ processor Lambda:
-  - Alert on messages in DLQ
-  - Log DLQ message details
-  - Optional: Manual retry mechanism
-- [ ] Add manual retry API endpoint (optional)
-- [ ] Create runbook for common errors:
-  - Customer endpoint down
-  - Invalid config
-  - Network issues
-- [ ] Test error scenarios
+**Morning (9am-12pm): Error Taxonomy and Breaker State**
+- [x] Finalize error classification matrix in `worker/src/services/delivery.rs`:
+  - Retryable network/transient failures (timeout, DNS/connect reset, 5xx, 429)
+  - Non-retryable customer errors (most 4xx, invalid URL/signature expectations)
+  - Internal/service errors (missing config/event, serialization/parse failures)
+- [ ] Add deterministic mapping from error class -> worker action:
+  - `retry` (requeue with computed backoff)
+  - `fail_terminal` (mark failed, no more retries)
+  - `drop_invalid` (record attempt + diagnostic reason)
+- [ ] Implement deferred resilience hardening from Day 7:
+  - Persist circuit-breaker state (open/half-open/closed) in DynamoDB
+  - Load breaker state at worker boot and refresh during processing
+
+**Afternoon (1pm-5pm): DLQ Operations + Runbook**
+- [ ] Add DLQ processing utility/script in `scripts/`:
+  - Poll and decode DLQ messages
+  - Summarize root-cause buckets by error class
+  - Support safe replay for selected message IDs (dry-run default)
+- [x] Emit resilience metrics:
+  - `CircuitBreakerOpen`, `CircuitBreakerHalfOpen`, `CircuitBreakerClose`
+  - `RetryDelayMs`, `VisibilityTimeoutSeconds`, `DlqReplayCount`
+- [ ] Write operator docs:
+  - `docs/runbook.md`: DLQ triage and replay steps
+  - `docs/troubleshooting.md`: error-class playbook and escalation path
+- [ ] Run scenario tests:
+  - Endpoint outage (5xx/timeouts)
+  - Permanent 4xx failure
+  - Missing/disabled config
+  - Validate expected transition to DLQ and replay behavior
 
 **Deliverables:**
-- Error handling improved
-- DLQ processor created
-- Runbook complete
+- Error classification matrix implemented and validated
+- Circuit-breaker state persistence shipped
+- DLQ triage/replay workflow documented and tested
+- Resilience metrics visible in CloudWatch
 
-**Commit:** `feat: enhance error handling and add DLQ processor`
+**Commit:** `feat: harden error handling, persist breaker state, and add DLQ ops workflow`
 
 ---
 

--- a/infra/ecs/README.md
+++ b/infra/ecs/README.md
@@ -18,7 +18,6 @@ This folder contains copy-pasteable templates and a deploy helper for the non-La
 ## Required environment variables for deploy script
 
 - `AWS_REGION`
-- `AWS_ACCOUNT_ID`
 - `ECS_CLUSTER`
 - `ECS_SERVICE`
 - `WORKER_TASK_ROLE_ARN`
@@ -30,6 +29,8 @@ Optional:
 - `CPU` (default: `256`)
 - `MEMORY` (default: `512`)
 - `CONTAINER_NAME` (default: `worker`)
+- `TASK_FAMILY` (default: `ECS_SERVICE`)
+- `LOG_GROUP_NAME` (default: `/ecs/${ECS_SERVICE}`)
 - `DESIRED_COUNT` (default: unchanged)
 
 ## Create policy from template
@@ -48,11 +49,11 @@ Attach `/tmp/worker-task-policy.json` to your worker task role.
 ```bash
 export AWS_REGION=us-west-2
 export AWS_ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
-export ECS_CLUSTER=hooray-relay
-export ECS_SERVICE=hooray-relay-worker
-export WORKER_TASK_ROLE_ARN=arn:aws:iam::123456789012:role/hooray-relay-worker-task-role
-export WORKER_EXECUTION_ROLE_ARN=arn:aws:iam::123456789012:role/ecsTaskExecutionRole
-export WORKER_IMAGE_URI=123456789012.dkr.ecr.us-west-2.amazonaws.com/hooray-relay-worker:abc123
+export ECS_CLUSTER=hooray-relay-worker-dev
+export ECS_SERVICE=hooray-relay-worker-dev
+export WORKER_TASK_ROLE_ARN=arn:aws:iam::123456789012:role/hooray-relay-worker-task-dev
+export WORKER_EXECUTION_ROLE_ARN=arn:aws:iam::123456789012:role/hooray-relay-worker-exec-dev
+export WORKER_IMAGE_URI=123456789012.dkr.ecr.us-west-2.amazonaws.com/hooray-relay-worker-dev:dev-latest
 export STACK_NAME=hooray-dev
 
 ./infra/ecs/deploy_worker_service.sh
@@ -63,3 +64,4 @@ This script:
 2. Renders task definition JSON.
 3. Registers new task definition revision.
 4. Updates ECS service to that revision.
+5. Uses ARM64 runtime platform to match the worker deployment target.

--- a/infra/ecs/deploy_worker_service.sh
+++ b/infra/ecs/deploy_worker_service.sh
@@ -21,7 +21,6 @@ require_cmd aws
 require_cmd envsubst
 
 AWS_REGION="${AWS_REGION:-}"
-AWS_ACCOUNT_ID="${AWS_ACCOUNT_ID:-}"
 ECS_CLUSTER="${ECS_CLUSTER:-}"
 ECS_SERVICE="${ECS_SERVICE:-}"
 WORKER_TASK_ROLE_ARN="${WORKER_TASK_ROLE_ARN:-}"
@@ -31,11 +30,11 @@ STACK_NAME="${STACK_NAME:-hooray-dev}"
 CPU="${CPU:-256}"
 MEMORY="${MEMORY:-512}"
 CONTAINER_NAME="${CONTAINER_NAME:-worker}"
-LOG_GROUP_NAME="${LOG_GROUP_NAME:-/ecs/hooray-relay-worker}"
+TASK_FAMILY="${TASK_FAMILY:-${ECS_SERVICE:-hooray-relay-worker}}"
+LOG_GROUP_NAME="${LOG_GROUP_NAME:-/ecs/${ECS_SERVICE:-hooray-relay-worker}}"
 DESIRED_COUNT="${DESIRED_COUNT:-}"
 
 require_set AWS_REGION
-require_set AWS_ACCOUNT_ID
 require_set ECS_CLUSTER
 require_set ECS_SERVICE
 require_set WORKER_TASK_ROLE_ARN
@@ -57,8 +56,13 @@ QUEUE_URL="$(aws cloudformation describe-stacks \
   --region "$AWS_REGION" \
   --query "Stacks[0].Outputs[?OutputKey=='QueueUrl'].OutputValue" \
   --output text)"
+BREAKER_STATES_TABLE="$(aws cloudformation describe-stacks \
+  --stack-name "$STACK_NAME" \
+  --region "$AWS_REGION" \
+  --query "Stacks[0].Outputs[?OutputKey=='BreakerStatesTableName'].OutputValue" \
+  --output text)"
 
-for resolved in EVENTS_TABLE CONFIGS_TABLE QUEUE_URL; do
+for resolved in EVENTS_TABLE CONFIGS_TABLE QUEUE_URL BREAKER_STATES_TABLE; do
   if [[ -z "${!resolved}" || "${!resolved}" == "None" ]]; then
     echo "ERROR: could not resolve ${resolved} from stack ${STACK_NAME}" >&2
     exit 1
@@ -68,9 +72,9 @@ done
 tmp_task_json="$(mktemp)"
 trap 'rm -f "$tmp_task_json"' EXIT
 
-export AWS_REGION AWS_ACCOUNT_ID CPU MEMORY CONTAINER_NAME LOG_GROUP_NAME \
+export AWS_REGION CPU MEMORY CONTAINER_NAME LOG_GROUP_NAME TASK_FAMILY \
   WORKER_TASK_ROLE_ARN WORKER_EXECUTION_ROLE_ARN WORKER_IMAGE_URI \
-  EVENTS_TABLE CONFIGS_TABLE QUEUE_URL
+  EVENTS_TABLE CONFIGS_TABLE QUEUE_URL BREAKER_STATES_TABLE
 
 envsubst < infra/ecs/task-definition.template.json > "$tmp_task_json"
 

--- a/infra/ecs/task-definition.template.json
+++ b/infra/ecs/task-definition.template.json
@@ -1,7 +1,11 @@
 {
-  "family": "hooray-relay-worker",
+  "family": "${TASK_FAMILY}",
   "networkMode": "awsvpc",
   "requiresCompatibilities": ["FARGATE"],
+  "runtimePlatform": {
+    "cpuArchitecture": "ARM64",
+    "operatingSystemFamily": "LINUX"
+  },
   "cpu": "${CPU}",
   "memory": "${MEMORY}",
   "executionRoleArn": "${WORKER_EXECUTION_ROLE_ARN}",
@@ -16,6 +20,7 @@
         { "name": "QUEUE_URL", "value": "${QUEUE_URL}" },
         { "name": "EVENTS_TABLE", "value": "${EVENTS_TABLE}" },
         { "name": "CONFIGS_TABLE", "value": "${CONFIGS_TABLE}" },
+        { "name": "BREAKER_STATES_TABLE", "value": "${BREAKER_STATES_TABLE}" },
         { "name": "RUST_LOG", "value": "info" }
       ],
       "logConfiguration": {

--- a/infra/ecs/worker-task-policy.template.json
+++ b/infra/ecs/worker-task-policy.template.json
@@ -30,6 +30,15 @@
         "dynamodb:GetItem"
       ],
       "Resource": "arn:aws:dynamodb:${AWS_REGION}:${AWS_ACCOUNT_ID}:table/webhook_configs_${ENVIRONMENT}"
+    },
+    {
+      "Sid": "DynamoBreakerStateRw",
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:GetItem",
+        "dynamodb:PutItem"
+      ],
+      "Resource": "arn:aws:dynamodb:${AWS_REGION}:${AWS_ACCOUNT_ID}:table/webhook_breaker_states_${ENVIRONMENT}"
     }
   ]
 }

--- a/template.yaml
+++ b/template.yaml
@@ -203,6 +203,35 @@ Resources:
           Value: engineer1
 
   # -------------------------------------------------------------------------
+  # DynamoDB Table 4: webhook_breaker_states
+  # Owned by: Engineer 2 (delivery resilience)
+  # -------------------------------------------------------------------------
+  WebhookBreakerStatesTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Sub "webhook_breaker_states_${Environment}"
+      BillingMode: PAY_PER_REQUEST
+      AttributeDefinitions:
+        - AttributeName: pk
+          AttributeType: S
+        - AttributeName: sk
+          AttributeType: S
+      KeySchema:
+        - AttributeName: pk
+          KeyType: HASH
+        - AttributeName: sk
+          KeyType: RANGE
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
+      Tags:
+        - Key: Project
+          Value: hooray-relay
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Owner
+          Value: engineer2
+
+  # -------------------------------------------------------------------------
   # SQS: Dead-Letter Queue
   # Messages land here when max_receive_count is exceeded.
   # Engineer 2 owns the alarm; shared infra definition.
@@ -461,6 +490,11 @@ Resources:
                 Action:
                   - dynamodb:GetItem
                 Resource: !GetAtt WebhookConfigsTable.Arn
+              - Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:PutItem
+                Resource: !GetAtt WebhookBreakerStatesTable.Arn
       Tags:
         - Key: Project
           Value: hooray-relay
@@ -496,6 +530,8 @@ Resources:
               Value: !Ref WebhookEventsTable
             - Name: CONFIGS_TABLE
               Value: !Ref WebhookConfigsTable
+            - Name: BREAKER_STATES_TABLE
+              Value: !Ref WebhookBreakerStatesTable
             - Name: RUST_LOG
               Value: info
           LogConfiguration:
@@ -544,6 +580,12 @@ Outputs:
     Value: !Ref WebhookConfigsTable
     Export:
       Name: !Sub "hooray-relay-configs-table-${Environment}"
+
+  BreakerStatesTableName:
+    Description: "webhook_breaker_states DynamoDB table name"
+    Value: !Ref WebhookBreakerStatesTable
+    Export:
+      Name: !Sub "hooray-relay-breaker-states-table-${Environment}"
 
   QueueUrl:
     Description: "SQS delivery queue URL"

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -6,8 +6,8 @@ use aws_sdk_dynamodb::Client as DynamoDbClient;
 use aws_sdk_sqs::types::Message;
 use chrono::Duration as ChronoDuration;
 use observability::Observability;
-use resilience::ResilienceConfig;
 use resilience::BreakerMode;
+use resilience::ResilienceConfig;
 use resilience::breaker::{on_failure, on_success, should_allow_request};
 use resilience::retry::{
     build_resilience_outcome_from_delivery_result, calculate_retry_decision,
@@ -20,7 +20,8 @@ use tokio::sync::Mutex;
 use tracing::{error, info, warn};
 
 use crate::model::{
-    DeliveryErrorClass, DeliveryResult, EventStatus, QueueMessage, WorkerError, classify_worker_error,
+    DeliveryErrorClass, DeliveryResult, EventStatus, QueueMessage, WorkerError,
+    classify_worker_error,
 };
 
 #[derive(Clone, Copy)]
@@ -170,7 +171,11 @@ impl Worker {
         let mut breaker_state = self.get_breaker_state(&endpoint_key).await;
         let before_gate_mode = breaker_state.mode;
         if !should_allow_request(&mut breaker_state, now) {
-            self.emit_breaker_transition_metric(&event.customer_id, before_gate_mode, breaker_state.mode);
+            self.emit_breaker_transition_metric(
+                &event.customer_id,
+                before_gate_mode,
+                breaker_state.mode,
+            );
             let retry_delay_secs = self.retry_delay_from_breaker(now, &breaker_state).max(1);
             self.set_breaker_state(endpoint_key.clone(), breaker_state)
                 .await;
@@ -182,7 +187,11 @@ impl Worker {
                 )
                 .await;
         }
-        self.emit_breaker_transition_metric(&event.customer_id, before_gate_mode, breaker_state.mode);
+        self.emit_breaker_transition_metric(
+            &event.customer_id,
+            before_gate_mode,
+            breaker_state.mode,
+        );
         self.set_breaker_state(endpoint_key.clone(), breaker_state.clone())
             .await;
 
@@ -203,7 +212,11 @@ impl Worker {
                     chrono::Utc::now().timestamp(),
                     &self.resilience_config,
                 );
-                self.emit_breaker_transition_metric(&event.customer_id, prev_mode, breaker_state.mode);
+                self.emit_breaker_transition_metric(
+                    &event.customer_id,
+                    prev_mode,
+                    breaker_state.mode,
+                );
                 self.set_breaker_state(endpoint_key.clone(), breaker_state)
                     .await;
                 event.mark_delivered(chrono::Utc::now().timestamp());
@@ -218,7 +231,11 @@ impl Worker {
                     chrono::Utc::now().timestamp(),
                     &self.resilience_config,
                 );
-                self.emit_breaker_transition_metric(&event.customer_id, prev_mode, breaker_state.mode);
+                self.emit_breaker_transition_metric(
+                    &event.customer_id,
+                    prev_mode,
+                    breaker_state.mode,
+                );
                 self.set_breaker_state(endpoint_key.clone(), breaker_state.clone())
                     .await;
                 let outcome = build_resilience_outcome_from_delivery_result(DeliveryResult::Retry);
@@ -259,7 +276,11 @@ impl Worker {
                     chrono::Utc::now().timestamp(),
                     &self.resilience_config,
                 );
-                self.emit_breaker_transition_metric(&event.customer_id, prev_mode, breaker_state.mode);
+                self.emit_breaker_transition_metric(
+                    &event.customer_id,
+                    prev_mode,
+                    breaker_state.mode,
+                );
                 self.set_breaker_state(endpoint_key, breaker_state).await;
                 event.mark_failed();
                 self.dynamodb_service.update_event_status(&event).await?;
@@ -404,7 +425,9 @@ impl Worker {
                         error = %err,
                         "breaker version conflict; refreshing cached breaker state from DynamoDB"
                     );
-                    if let Some(latest) = self.dynamodb_service.get_breaker_state(&endpoint_key).await {
+                    if let Some(latest) =
+                        self.dynamodb_service.get_breaker_state(&endpoint_key).await
+                    {
                         let mut states = self.breaker_states.lock().await;
                         states.insert(endpoint_key, latest);
                     }
@@ -479,7 +502,9 @@ impl Worker {
         }
         match to {
             BreakerMode::Open => self.observability.emit_circuit_breaker_open(customer_id),
-            BreakerMode::HalfOpen => self.observability.emit_circuit_breaker_half_open(customer_id),
+            BreakerMode::HalfOpen => self
+                .observability
+                .emit_circuit_breaker_half_open(customer_id),
             BreakerMode::Closed => self.observability.emit_circuit_breaker_close(customer_id),
         }
     }

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -7,20 +7,34 @@ use aws_sdk_sqs::types::Message;
 use chrono::Duration as ChronoDuration;
 use observability::Observability;
 use resilience::ResilienceConfig;
+use resilience::BreakerMode;
 use resilience::breaker::{on_failure, on_success, should_allow_request};
-use resilience::retry::{build_resilience_outcome_from_delivery_result, calculate_retry_decision};
+use resilience::retry::{
+    build_resilience_outcome_from_delivery_result, calculate_retry_decision,
+    compute_visibility_timeout,
+};
 use services::{delivery::DeliveryService, dynamodb::DynamoDbService, sqs::SqsService};
 use std::collections::HashMap;
 use std::{env, time::Duration};
 use tokio::sync::Mutex;
 use tracing::{error, info, warn};
 
-use crate::model::{DeliveryResult, EventStatus, QueueMessage, WorkerError};
+use crate::model::{
+    DeliveryErrorClass, DeliveryResult, EventStatus, QueueMessage, WorkerError, classify_worker_error,
+};
 
 #[derive(Clone, Copy)]
 enum MessageAction {
     Delete,
     KeepForRetry { retry_delay_secs: i64 },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DeliveryPolicyAction {
+    Succeed,
+    Retry,
+    FailTerminal,
+    DropInvalid,
 }
 
 struct Worker {
@@ -57,6 +71,13 @@ impl Worker {
                     "CONFIGS_TABLE or WEBHOOK_CONFIGS_TABLE must be set".to_string(),
                 )
             })?;
+        let breaker_states_table = env::var("BREAKER_STATES_TABLE")
+            .or_else(|_| env::var("BREAKER_STATE_TABLE"))
+            .map_err(|_| {
+                WorkerError::InvalidMessage(
+                    "BREAKER_STATES_TABLE or BREAKER_STATE_TABLE must be set".to_string(),
+                )
+            })?;
         let resilience_config = ResilienceConfig::default();
         Ok(Worker {
             delivery_service: DeliveryService::new(),
@@ -70,6 +91,7 @@ impl Worker {
                 DynamoDbClient::new(&config),
                 events_table,
                 configs_table,
+                breaker_states_table,
             ),
             resilience_config,
             breaker_states: Mutex::new(HashMap::new()),
@@ -113,9 +135,7 @@ impl Worker {
     async fn deliver_event(&self, event_id: &str) -> Result<MessageAction, WorkerError> {
         let mut event = match self.dynamodb_service.get_event(event_id).await {
             Ok(event) => event,
-            Err(WorkerError::ItemNotFound {
-                entity: "Event", ..
-            }) => {
+            Err(WorkerError::EventNotFound(_)) => {
                 warn!(event_id = %event_id, "event not found, deleting message");
                 return Ok(MessageAction::Delete);
             }
@@ -129,10 +149,7 @@ impl Worker {
 
         let config = match self.dynamodb_service.get_config(&event.customer_id).await {
             Ok(config) => config,
-            Err(WorkerError::ItemNotFound {
-                entity: "WebhookConfig",
-                ..
-            }) => {
+            Err(WorkerError::ConfigNotFound(_)) => {
                 warn!(event_id = %event.event_id, customer_id = %event.customer_id, "missing config, marking failed");
                 event.mark_failed();
                 self.dynamodb_service.update_event_status(&event).await?;
@@ -151,7 +168,9 @@ impl Worker {
         let endpoint_key = event.customer_id.clone();
         let now = chrono::Utc::now().timestamp();
         let mut breaker_state = self.get_breaker_state(&endpoint_key).await;
+        let before_gate_mode = breaker_state.mode;
         if !should_allow_request(&mut breaker_state, now) {
+            self.emit_breaker_transition_metric(&event.customer_id, before_gate_mode, breaker_state.mode);
             let retry_delay_secs = self.retry_delay_from_breaker(now, &breaker_state).max(1);
             self.set_breaker_state(endpoint_key.clone(), breaker_state)
                 .await;
@@ -163,25 +182,28 @@ impl Worker {
                 )
                 .await;
         }
+        self.emit_breaker_transition_metric(&event.customer_id, before_gate_mode, breaker_state.mode);
         self.set_breaker_state(endpoint_key.clone(), breaker_state.clone())
             .await;
 
-        let (result, attempt) = self.delivery_service.deliver(&event, &config).await?;
+        let (classification, attempt) = self.delivery_service.deliver(&event, &config).await?;
         self.observability
-            .emit_delivery_attempt(&event, &attempt, &result);
+            .emit_delivery_attempt(&event, &attempt, &classification.result);
         self.dynamodb_service.record_attempt(attempt).await?;
         event.attempt_count += 1;
         self.dynamodb_service
             .increment_attempt_count(&event)
             .await?;
 
-        match result {
-            DeliveryResult::Success => {
+        match Self::policy_for_class(classification.class) {
+            DeliveryPolicyAction::Succeed => {
+                let prev_mode = breaker_state.mode;
                 on_success(
                     &mut breaker_state,
                     chrono::Utc::now().timestamp(),
                     &self.resilience_config,
                 );
+                self.emit_breaker_transition_metric(&event.customer_id, prev_mode, breaker_state.mode);
                 self.set_breaker_state(endpoint_key.clone(), breaker_state)
                     .await;
                 event.mark_delivered(chrono::Utc::now().timestamp());
@@ -189,12 +211,14 @@ impl Worker {
                 info!(event_id = %event.event_id, "event delivered successfully");
                 Ok(MessageAction::Delete)
             }
-            DeliveryResult::Retry => {
+            DeliveryPolicyAction::Retry => {
+                let prev_mode = breaker_state.mode;
                 on_failure(
                     &mut breaker_state,
                     chrono::Utc::now().timestamp(),
                     &self.resilience_config,
                 );
+                self.emit_breaker_transition_metric(&event.customer_id, prev_mode, breaker_state.mode);
                 self.set_breaker_state(endpoint_key.clone(), breaker_state.clone())
                     .await;
                 let outcome = build_resilience_outcome_from_delivery_result(DeliveryResult::Retry);
@@ -228,16 +252,24 @@ impl Worker {
                 )
                 .await
             }
-            DeliveryResult::Exhausted => {
+            DeliveryPolicyAction::FailTerminal => {
+                let prev_mode = breaker_state.mode;
                 on_failure(
                     &mut breaker_state,
                     chrono::Utc::now().timestamp(),
                     &self.resilience_config,
                 );
+                self.emit_breaker_transition_metric(&event.customer_id, prev_mode, breaker_state.mode);
                 self.set_breaker_state(endpoint_key, breaker_state).await;
                 event.mark_failed();
                 self.dynamodb_service.update_event_status(&event).await?;
                 info!(event_id = %event.event_id, "event delivery exhausted");
+                Ok(MessageAction::Delete)
+            }
+            DeliveryPolicyAction::DropInvalid => {
+                warn!(event_id = %event.event_id, "delivery classified as invalid/drop");
+                event.mark_failed();
+                self.dynamodb_service.update_event_status(&event).await?;
                 Ok(MessageAction::Delete)
             }
         }
@@ -259,14 +291,52 @@ impl Worker {
         let queue_message: QueueMessage = match serde_json::from_str(body) {
             Ok(parsed) => parsed,
             Err(err) => {
-                warn!(error = %err, body = %body, "invalid queue payload; deleting poison message");
+                let parse_err = WorkerError::Serialization(err.to_string());
+                let classification = classify_worker_error(&parse_err);
+                let action = Self::policy_for_worker_error(&parse_err);
+                warn!(
+                    error = %err,
+                    body = %body,
+                    error_class = classification.class.as_str(),
+                    policy_action = ?action,
+                    "invalid queue payload; deleting poison message"
+                );
                 self.sqs_service.delete_message(receipt_handle).await?;
                 return Ok(());
             }
         };
+        if queue_message
+            .attributes
+            .get("dlq_replay")
+            .is_some_and(|v| v == "true")
+        {
+            self.observability
+                .emit_dlq_replay_count(&queue_message.event_id, 1);
+        }
 
         info!(event_id = %queue_message.event_id, "received queue message");
-        match self.deliver_event(&queue_message.event_id).await? {
+        let action = match self.deliver_event(&queue_message.event_id).await {
+            Ok(action) => action,
+            Err(err) => {
+                let classification = classify_worker_error(&err);
+                let policy_action = Self::policy_for_worker_error(&err);
+                warn!(
+                    error = %err,
+                    event_id = %queue_message.event_id,
+                    error_class = classification.class.as_str(),
+                    policy_action = ?policy_action,
+                    "deliver_event failed; applying policy action"
+                );
+                match policy_action {
+                    DeliveryPolicyAction::Retry => return Err(err),
+                    DeliveryPolicyAction::FailTerminal
+                    | DeliveryPolicyAction::DropInvalid
+                    | DeliveryPolicyAction::Succeed => MessageAction::Delete,
+                }
+            }
+        };
+
+        match action {
             MessageAction::Delete => self.sqs_service.delete_message(receipt_handle).await?,
             MessageAction::KeepForRetry { retry_delay_secs } => {
                 self.sqs_service
@@ -289,11 +359,23 @@ impl Worker {
     }
 
     async fn get_breaker_state(&self, endpoint_key: &str) -> resilience::BreakerState {
+        {
+            let states = self.breaker_states.lock().await;
+            if let Some(state) = states.get(endpoint_key) {
+                return state.clone();
+            }
+        }
+
+        if let Some(state) = self.dynamodb_service.get_breaker_state(endpoint_key).await {
+            let mut states = self.breaker_states.lock().await;
+            states.insert(endpoint_key.to_string(), state.clone());
+            return state;
+        }
+
+        let default_state = Self::closed_breaker_state(endpoint_key.to_string());
         let mut states = self.breaker_states.lock().await;
-        states
-            .entry(endpoint_key.to_string())
-            .or_insert_with(Self::closed_breaker_state)
-            .clone()
+        states.insert(endpoint_key.to_string(), default_state.clone());
+        default_state
     }
 
     async fn set_breaker_state(
@@ -301,8 +383,43 @@ impl Worker {
         endpoint_key: String,
         breaker_state: resilience::BreakerState,
     ) {
-        let mut states = self.breaker_states.lock().await;
-        states.insert(endpoint_key, breaker_state);
+        let mut next_state = breaker_state;
+        next_state.endpoint_key = endpoint_key.clone();
+        let expected_version = next_state.version;
+        next_state.version = next_state.version.saturating_add(1);
+
+        match self
+            .dynamodb_service
+            .put_breaker_state(&endpoint_key, &next_state, expected_version)
+            .await
+        {
+            Ok(()) => {
+                let mut states = self.breaker_states.lock().await;
+                states.insert(endpoint_key, next_state);
+            }
+            Err(err) => {
+                if Self::is_breaker_version_conflict(&err) {
+                    warn!(
+                        endpoint_key = %endpoint_key,
+                        error = %err,
+                        "breaker version conflict; refreshing cached breaker state from DynamoDB"
+                    );
+                    if let Some(latest) = self.dynamodb_service.get_breaker_state(&endpoint_key).await {
+                        let mut states = self.breaker_states.lock().await;
+                        states.insert(endpoint_key, latest);
+                    }
+                    return;
+                }
+
+                warn!(
+                    endpoint_key = %endpoint_key,
+                    error = %err,
+                    "failed to persist breaker state; keeping in-memory state"
+                );
+                let mut states = self.breaker_states.lock().await;
+                states.insert(endpoint_key, next_state);
+            }
+        }
     }
 
     fn retry_delay_from_breaker(&self, now: i64, breaker_state: &resilience::BreakerState) -> i64 {
@@ -317,8 +434,9 @@ impl Worker {
             .unwrap_or(fallback)
     }
 
-    fn closed_breaker_state() -> resilience::BreakerState {
+    fn closed_breaker_state(endpoint_key: String) -> resilience::BreakerState {
         resilience::BreakerState {
+            endpoint_key,
             mode: resilience::BreakerMode::Closed,
             consecutive_failures: 0,
             consecutive_successes: 0,
@@ -331,6 +449,51 @@ impl Worker {
         }
     }
 
+    fn policy_for_class(class: DeliveryErrorClass) -> DeliveryPolicyAction {
+        match class {
+            DeliveryErrorClass::None => DeliveryPolicyAction::Succeed,
+            DeliveryErrorClass::InvalidQueueMessage | DeliveryErrorClass::SerializationError => {
+                DeliveryPolicyAction::DropInvalid
+            }
+            _ => match class.result() {
+                DeliveryResult::Success => DeliveryPolicyAction::Succeed,
+                DeliveryResult::Retry => DeliveryPolicyAction::Retry,
+                DeliveryResult::Exhausted => DeliveryPolicyAction::FailTerminal,
+            },
+        }
+    }
+
+    fn policy_for_worker_error(err: &WorkerError) -> DeliveryPolicyAction {
+        let classification = classify_worker_error(err);
+        Self::policy_for_class(classification.class)
+    }
+
+    fn emit_breaker_transition_metric(
+        &self,
+        customer_id: &str,
+        from: BreakerMode,
+        to: BreakerMode,
+    ) {
+        if from == to {
+            return;
+        }
+        match to {
+            BreakerMode::Open => self.observability.emit_circuit_breaker_open(customer_id),
+            BreakerMode::HalfOpen => self.observability.emit_circuit_breaker_half_open(customer_id),
+            BreakerMode::Closed => self.observability.emit_circuit_breaker_close(customer_id),
+        }
+    }
+
+    fn is_breaker_version_conflict(err: &WorkerError) -> bool {
+        match err {
+            WorkerError::DynamoDb(message) => {
+                message.contains("ConditionalCheckFailedException")
+                    || message.contains("conditional request failed")
+            }
+            _ => false,
+        }
+    }
+
     async fn schedule_retry(
         &self,
         event: &mut crate::model::Event,
@@ -338,6 +501,16 @@ impl Worker {
         reason: &str,
     ) -> Result<MessageAction, WorkerError> {
         let next_retry_at = chrono::Utc::now().timestamp() + retry_delay_secs.max(1);
+        let retry_delay_ms = retry_delay_secs.max(1) * 1_000;
+        let visibility_timeout_secs = compute_visibility_timeout(
+            ChronoDuration::seconds(retry_delay_secs.max(1)),
+            &self.resilience_config,
+        )
+        .num_seconds();
+        self.observability
+            .emit_retry_delay_ms(&event.customer_id, retry_delay_ms);
+        self.observability
+            .emit_visibility_timeout_seconds(&event.customer_id, visibility_timeout_secs);
         event.mark_retry_scheduled(next_retry_at);
         self.dynamodb_service.update_event_status(event).await?;
         info!(

--- a/worker/src/model.rs
+++ b/worker/src/model.rs
@@ -136,12 +136,94 @@ impl DeliveryAttempt {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DeliveryResult {
     Success,
     Retry,
     Exhausted,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeliveryErrorClass {
+    None,
+    HttpRateLimited,
+    HttpServerError,
+    HttpClientError,
+    HttpOther,
+    NetworkTimeout,
+    NetworkConnect,
+    NetworkRequest,
+    TransportOther,
+    EventMissing,
+    ConfigMissing,
+    ConfigInactive,
+    InvalidQueueMessage,
+    SerializationError,
+    DynamoDbError,
+    SqsError,
+    InternalError,
+}
+
+impl DeliveryErrorClass {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            DeliveryErrorClass::None => "none",
+            DeliveryErrorClass::HttpRateLimited => "http_rate_limited",
+            DeliveryErrorClass::HttpServerError => "http_server_error",
+            DeliveryErrorClass::HttpClientError => "http_client_error",
+            DeliveryErrorClass::HttpOther => "http_other",
+            DeliveryErrorClass::NetworkTimeout => "network_timeout",
+            DeliveryErrorClass::NetworkConnect => "network_connect",
+            DeliveryErrorClass::NetworkRequest => "network_request",
+            DeliveryErrorClass::TransportOther => "transport_other",
+            DeliveryErrorClass::EventMissing => "event_missing",
+            DeliveryErrorClass::ConfigMissing => "config_missing",
+            DeliveryErrorClass::ConfigInactive => "config_inactive",
+            DeliveryErrorClass::InvalidQueueMessage => "invalid_queue_message",
+            DeliveryErrorClass::SerializationError => "serialization_error",
+            DeliveryErrorClass::DynamoDbError => "dynamodb_error",
+            DeliveryErrorClass::SqsError => "sqs_error",
+            DeliveryErrorClass::InternalError => "internal_error",
+        }
+    }
+
+    pub fn result(self) -> DeliveryResult {
+        match self {
+            DeliveryErrorClass::None => DeliveryResult::Success,
+            DeliveryErrorClass::HttpRateLimited
+            | DeliveryErrorClass::HttpServerError
+            | DeliveryErrorClass::HttpOther
+            | DeliveryErrorClass::NetworkTimeout
+            | DeliveryErrorClass::NetworkConnect
+            | DeliveryErrorClass::NetworkRequest
+            | DeliveryErrorClass::DynamoDbError
+            | DeliveryErrorClass::SqsError => DeliveryResult::Retry,
+            DeliveryErrorClass::HttpClientError
+            | DeliveryErrorClass::TransportOther
+            | DeliveryErrorClass::EventMissing
+            | DeliveryErrorClass::ConfigMissing
+            | DeliveryErrorClass::ConfigInactive
+            | DeliveryErrorClass::InvalidQueueMessage
+            | DeliveryErrorClass::SerializationError
+            | DeliveryErrorClass::InternalError => DeliveryResult::Exhausted,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeliveryClassification {
+    pub result: DeliveryResult,
+    pub class: DeliveryErrorClass,
+}
+
+impl DeliveryClassification {
+    pub fn from_class(class: DeliveryErrorClass) -> Self {
+        Self {
+            result: class.result(),
+            class,
+        }
+    }
 }
 
 #[derive(Debug, Error)]
@@ -171,6 +253,40 @@ pub enum WorkerError {
 impl From<serde_dynamo::Error> for WorkerError {
     fn from(err: serde_dynamo::Error) -> Self {
         WorkerError::DecodeDynamo(err.to_string())
+    }
+}
+
+pub fn classify_worker_error(err: &WorkerError) -> DeliveryClassification {
+    match err {
+        WorkerError::EventNotFound(_) => {
+            DeliveryClassification::from_class(DeliveryErrorClass::EventMissing)
+        }
+        WorkerError::ConfigNotFound(_) => {
+            DeliveryClassification::from_class(DeliveryErrorClass::ConfigMissing)
+        }
+        WorkerError::InactiveConfig(_) => {
+            DeliveryClassification::from_class(DeliveryErrorClass::ConfigInactive)
+        }
+        WorkerError::InvalidMessage(_) => {
+            DeliveryClassification::from_class(DeliveryErrorClass::InvalidQueueMessage)
+        }
+        WorkerError::Serialization(_) | WorkerError::DecodeDynamo(_) => {
+            DeliveryClassification::from_class(DeliveryErrorClass::SerializationError)
+        }
+        WorkerError::DynamoDb(_) => {
+            DeliveryClassification::from_class(DeliveryErrorClass::DynamoDbError)
+        }
+        WorkerError::Sqs(_) => DeliveryClassification::from_class(DeliveryErrorClass::SqsError),
+        WorkerError::Delivery(_) => {
+            DeliveryClassification::from_class(DeliveryErrorClass::InternalError)
+        }
+        WorkerError::ItemNotFound { entity, .. } => match *entity {
+            "Event" => DeliveryClassification::from_class(DeliveryErrorClass::EventMissing),
+            "WebhookConfig" => {
+                DeliveryClassification::from_class(DeliveryErrorClass::ConfigMissing)
+            }
+            _ => DeliveryClassification::from_class(DeliveryErrorClass::InternalError),
+        },
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -286,5 +402,28 @@ mod tests {
         assert_eq!(event.status, EventStatus::Delivered);
         assert_eq!(event.delivered_at, Some(1_707_840_120));
         assert_eq!(event.next_retry_at, None);
+    }
+
+    #[test]
+    fn delivery_error_class_maps_to_expected_result() {
+        assert_eq!(
+            DeliveryErrorClass::HttpServerError.result(),
+            DeliveryResult::Retry
+        );
+        assert_eq!(
+            DeliveryErrorClass::HttpClientError.result(),
+            DeliveryResult::Exhausted
+        );
+        assert_eq!(DeliveryErrorClass::None.result(), DeliveryResult::Success);
+    }
+
+    #[test]
+    fn classify_worker_error_maps_item_not_found_event() {
+        let classification = classify_worker_error(&WorkerError::ItemNotFound {
+            entity: "Event",
+            key: "evt_123".to_string(),
+        });
+        assert_eq!(classification.class, DeliveryErrorClass::EventMissing);
+        assert_eq!(classification.result, DeliveryResult::Exhausted);
     }
 }

--- a/worker/src/observability.rs
+++ b/worker/src/observability.rs
@@ -128,7 +128,12 @@ impl Observability {
 
     pub fn emit_retry_delay_ms(&self, customer_id: &str, retry_delay_ms: i64) {
         let dimensions = self.resilience_dimensions(customer_id);
-        self.emit_metric("RetryDelayMs", "Milliseconds", retry_delay_ms as f64, &dimensions);
+        self.emit_metric(
+            "RetryDelayMs",
+            "Milliseconds",
+            retry_delay_ms as f64,
+            &dimensions,
+        );
     }
 
     pub fn emit_visibility_timeout_seconds(&self, customer_id: &str, visibility_timeout: i64) {

--- a/worker/src/observability.rs
+++ b/worker/src/observability.rs
@@ -111,6 +111,41 @@ impl Observability {
         self.emit_metric("webhook.queue.depth", "Count", depth as f64, &dimensions);
     }
 
+    pub fn emit_circuit_breaker_open(&self, customer_id: &str) {
+        let dimensions = self.resilience_dimensions(customer_id);
+        self.emit_metric("CircuitBreakerOpen", "Count", 1.0, &dimensions);
+    }
+
+    pub fn emit_circuit_breaker_half_open(&self, customer_id: &str) {
+        let dimensions = self.resilience_dimensions(customer_id);
+        self.emit_metric("CircuitBreakerHalfOpen", "Count", 1.0, &dimensions);
+    }
+
+    pub fn emit_circuit_breaker_close(&self, customer_id: &str) {
+        let dimensions = self.resilience_dimensions(customer_id);
+        self.emit_metric("CircuitBreakerClose", "Count", 1.0, &dimensions);
+    }
+
+    pub fn emit_retry_delay_ms(&self, customer_id: &str, retry_delay_ms: i64) {
+        let dimensions = self.resilience_dimensions(customer_id);
+        self.emit_metric("RetryDelayMs", "Milliseconds", retry_delay_ms as f64, &dimensions);
+    }
+
+    pub fn emit_visibility_timeout_seconds(&self, customer_id: &str, visibility_timeout: i64) {
+        let dimensions = self.resilience_dimensions(customer_id);
+        self.emit_metric(
+            "VisibilityTimeoutSeconds",
+            "Seconds",
+            visibility_timeout as f64,
+            &dimensions,
+        );
+    }
+
+    pub fn emit_dlq_replay_count(&self, customer_id: &str, count: u64) {
+        let dimensions = self.resilience_dimensions(customer_id);
+        self.emit_metric("DlqReplayCount", "Count", count as f64, &dimensions);
+    }
+
     fn emit_metric(
         &self,
         metric_name: &str,
@@ -122,6 +157,14 @@ impl Observability {
             "{}",
             build_metric_payload(&self.namespace, metric_name, unit, value, dimensions,)
         );
+    }
+
+    fn resilience_dimensions(&self, customer_id: &str) -> Vec<(String, String)> {
+        vec![
+            ("environment".to_string(), self.environment.clone()),
+            ("queue_name".to_string(), self.queue_name.clone()),
+            ("customer_id".to_string(), customer_id.to_string()),
+        ]
     }
 }
 

--- a/worker/src/resilience/mod.rs
+++ b/worker/src/resilience/mod.rs
@@ -50,6 +50,7 @@ pub enum BreakerMode {
 
 #[derive(Debug, Clone)]
 pub struct BreakerState {
+    pub endpoint_key: String,
     pub mode: BreakerMode,
     pub consecutive_failures: u32,
     pub consecutive_successes: u32,
@@ -59,6 +60,16 @@ pub struct BreakerState {
     pub last_success_at: Option<UnixTimestamp>,
     pub half_open_in_flight: bool,
     pub version: u64,
+}
+
+impl BreakerState {
+    pub fn pk(endpoint_key: String) -> String {
+        format!("BREAKER#{}", endpoint_key)
+    }
+
+    pub fn sk() -> &'static str {
+        "STATE"
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/worker/src/resilience/retry.rs
+++ b/worker/src/resilience/retry.rs
@@ -97,6 +97,7 @@ mod tests {
 
     fn closed_breaker_state() -> BreakerState {
         BreakerState {
+            endpoint_key: "test-endpoint".to_string(),
             mode: BreakerMode::Closed,
             consecutive_failures: 0,
             consecutive_successes: 0,

--- a/worker/src/services/delivery.rs
+++ b/worker/src/services/delivery.rs
@@ -1,5 +1,8 @@
 use crate::{
-    model::{DeliveryAttempt, DeliveryResult, Event, WebhookConfig, WorkerError},
+    model::{
+        DeliveryAttempt, DeliveryClassification, DeliveryErrorClass, DeliveryResult, Event,
+        WebhookConfig, WorkerError,
+    },
     services::signature::SignatureService,
 };
 use std::time::{Duration, Instant};
@@ -27,7 +30,7 @@ impl DeliveryService {
         &self,
         event: &Event,
         config: &WebhookConfig,
-    ) -> Result<(DeliveryResult, DeliveryAttempt), WorkerError> {
+    ) -> Result<(DeliveryClassification, DeliveryAttempt), WorkerError> {
         let attempt_number = event.attempt_count + 1;
         let attempted_at = chrono::Utc::now().timestamp();
         let (timestamp, signature) =
@@ -46,23 +49,25 @@ impl DeliveryService {
             .await;
         let response_time_ms = start.elapsed().as_millis() as u64;
 
-        let (result, http_status, error_message) = match res {
+        let (classification, http_status, error_message) = match res {
             Ok(response) => {
                 let status = response.status();
-                if status.is_success() {
-                    (DeliveryResult::Success, Some(status.as_u16()), None)
+                let classification = classify_http_status(status.as_u16());
+                let message = if classification.result == DeliveryResult::Success {
+                    None
                 } else {
-                    let result = classify_http_status(status.as_u16());
-                    (
-                        result,
-                        Some(status.as_u16()),
-                        Some(format!("HTTP {}", status.as_u16())),
-                    )
-                }
+                    Some(format!(
+                        "[{}] HTTP {}",
+                        classification.class.as_str(),
+                        status.as_u16()
+                    ))
+                };
+                (classification, Some(status.as_u16()), message)
             }
             Err(err) => {
-                let result = classify_reqwest_error(&err);
-                (result, None, Some(err.to_string()))
+                let classification = classify_reqwest_error(&err);
+                let class = classification.class.as_str();
+                (classification, None, Some(format!("[{}] {}", class, err)))
             }
         };
 
@@ -75,39 +80,57 @@ impl DeliveryService {
             error_message,
         );
 
-        Ok((result, attempt))
+        Ok((classification, attempt))
     }
 }
 
-fn classify_http_status(status: u16) -> DeliveryResult {
+fn classify_http_status(status: u16) -> DeliveryClassification {
     match status {
-        200..=299 => DeliveryResult::Success,
-        408 | 409 | 429 | 500..=599 => DeliveryResult::Retry,
-        400 | 401 | 403 | 404 | 422 => DeliveryResult::Exhausted,
-        402 | 405..=407 | 410..=421 | 423..=428 | 430..=499 => DeliveryResult::Exhausted,
-        _ => DeliveryResult::Retry,
+        200..=299 => DeliveryClassification::from_class(DeliveryErrorClass::None),
+        408 | 409 => DeliveryClassification::from_class(DeliveryErrorClass::HttpOther),
+        429 => DeliveryClassification::from_class(DeliveryErrorClass::HttpRateLimited),
+        500..=599 => DeliveryClassification::from_class(DeliveryErrorClass::HttpServerError),
+        400..=499 => DeliveryClassification::from_class(DeliveryErrorClass::HttpClientError),
+        _ => DeliveryClassification::from_class(DeliveryErrorClass::HttpOther),
     }
 }
 
-fn classify_reqwest_error(err: &reqwest::Error) -> DeliveryResult {
+fn classify_reqwest_error(err: &reqwest::Error) -> DeliveryClassification {
     if err.is_timeout() || err.is_connect() || err.is_request() {
-        DeliveryResult::Retry
+        let class = if err.is_timeout() {
+            DeliveryErrorClass::NetworkTimeout
+        } else if err.is_connect() {
+            DeliveryErrorClass::NetworkConnect
+        } else {
+            DeliveryErrorClass::NetworkRequest
+        };
+        DeliveryClassification::from_class(class)
     } else {
-        DeliveryResult::Exhausted
+        DeliveryClassification::from_class(DeliveryErrorClass::TransportOther)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::classify_http_status;
+    use super::{DeliveryErrorClass, classify_http_status};
     use crate::model::DeliveryResult;
 
     #[test]
     fn classify_http_status_matches_contract() {
-        assert_eq!(classify_http_status(200), DeliveryResult::Success);
-        assert_eq!(classify_http_status(500), DeliveryResult::Retry);
-        assert_eq!(classify_http_status(429), DeliveryResult::Retry);
-        assert_eq!(classify_http_status(404), DeliveryResult::Exhausted);
-        assert_eq!(classify_http_status(422), DeliveryResult::Exhausted);
+        let ok = classify_http_status(200);
+        assert_eq!(ok.result, DeliveryResult::Success);
+        assert_eq!(ok.class, DeliveryErrorClass::None);
+
+        let server = classify_http_status(500);
+        assert_eq!(server.result, DeliveryResult::Retry);
+        assert_eq!(server.class, DeliveryErrorClass::HttpServerError);
+
+        let throttled = classify_http_status(429);
+        assert_eq!(throttled.result, DeliveryResult::Retry);
+        assert_eq!(throttled.class, DeliveryErrorClass::HttpRateLimited);
+
+        let client = classify_http_status(404);
+        assert_eq!(client.result, DeliveryResult::Exhausted);
+        assert_eq!(client.class, DeliveryErrorClass::HttpClientError);
     }
 }

--- a/worker/src/services/dynamodb.rs
+++ b/worker/src/services/dynamodb.rs
@@ -1,4 +1,7 @@
-use crate::model::{DeliveryAttempt, Event, EventStatus, WebhookConfig, WorkerError};
+use crate::{
+    model::{DeliveryAttempt, Event, EventStatus, WebhookConfig, WorkerError},
+    resilience::{BreakerMode, BreakerState},
+};
 use aws_sdk_dynamodb::Client;
 use aws_sdk_dynamodb::types::AttributeValue;
 use std::collections::HashMap;
@@ -117,6 +120,7 @@ pub struct DynamoDbService {
     webhook_events_table: String,
     // webhook_idempotency_table: String,
     webhook_configs_table: String,
+    breaker_states_table: String,
 }
 
 impl DynamoDbService {
@@ -125,12 +129,14 @@ impl DynamoDbService {
         webhook_events_table: String,
         // webhook_idempotency_table: String,
         webhook_configs_table: String,
+        breaker_states_table: String,
     ) -> Self {
         Self {
             client,
             webhook_events_table,
             // webhook_idempotency_table,
             webhook_configs_table,
+            breaker_states_table,
         }
     }
 
@@ -152,7 +158,10 @@ impl DynamoDbService {
                 WorkerError::DynamoDb(format!("Failed to fetch event with ID {}: {}", event_id, e))
             })?;
 
-        let event = parse_event_item(resp.item)?;
+        let item = resp
+            .item
+            .ok_or_else(|| WorkerError::EventNotFound(event_id.to_string()))?;
+        let event = parse_event_item(Some(item))?;
         info!(attempt_count = event.attempt_count, "fetched event");
         Ok(event)
     }
@@ -179,7 +188,10 @@ impl DynamoDbService {
                 ))
             })?;
 
-        let config = parse_config_item(resp.item)?;
+        let item = resp
+            .item
+            .ok_or_else(|| WorkerError::ConfigNotFound(customer_id.to_string()))?;
+        let config = parse_config_item(Some(item))?;
         if config.active {
             info!("fetched active webhook config");
         } else {
@@ -306,6 +318,166 @@ impl DynamoDbService {
 
         info!("updated attempt count");
         Ok(())
+    }
+
+    #[instrument(skip(self), fields(endpoint_key = %endpoint_key))]
+    pub async fn get_breaker_state(&self, endpoint_key: &str) -> Option<BreakerState> {
+        // Implementation would involve fetching the breaker state item from DynamoDB and parsing it
+        info!("fetching breaker state");
+        let pk = BreakerState::pk(endpoint_key.to_string());
+        let sk = BreakerState::sk().to_string();
+
+        match self
+            .client
+            .get_item()
+            .table_name(&self.breaker_states_table)
+            .key("pk", AttributeValue::S(pk))
+            .key("sk", AttributeValue::S(sk))
+            .send()
+            .await
+        {
+            Ok(resp) => {
+                if let Some(item) = resp.item {
+                    match parse_breaker_state_item(item) {
+                        Ok(state) => {
+                            info!(mode = ?state.mode, "fetched breaker state");
+                            Some(state)
+                        }
+                        Err(e) => {
+                            error!(error = %e, "failed to parse breaker state item");
+                            None
+                        }
+                    }
+                } else {
+                    info!("breaker state not found");
+                    None
+                }
+            }
+            Err(e) => {
+                error!(error = %e, "failed to fetch breaker state");
+                None
+            }
+        }
+    }
+
+    pub async fn put_breaker_state(
+        &self,
+        endpoint_key: &str,
+        state: &BreakerState,
+        expected_version: u64,
+    ) -> Result<(), WorkerError> {
+        self.client
+            .put_item()
+            .table_name(&self.breaker_states_table)
+            .condition_expression("attribute_not_exists(#version) OR #version = :expected_version")
+            .expression_attribute_names("#version", "version")
+            .expression_attribute_values(
+                ":expected_version",
+                AttributeValue::N(expected_version.to_string()),
+            )
+            .item(
+                "pk",
+                AttributeValue::S(BreakerState::pk(endpoint_key.to_string())),
+            )
+            .item("sk", AttributeValue::S(BreakerState::sk().to_string()))
+            .item(
+                "endpoint_key",
+                AttributeValue::S(endpoint_key.to_string()),
+            )
+            .item(
+                "mode",
+                AttributeValue::S(
+                    match state.mode {
+                        BreakerMode::Closed => "closed",
+                        BreakerMode::Open => "open",
+                        BreakerMode::HalfOpen => "half_open",
+                    }
+                    .to_string(),
+                ),
+            )
+            .item(
+                "consecutive_failures",
+                AttributeValue::N(state.consecutive_failures.to_string()),
+            )
+            .item(
+                "consecutive_successes",
+                AttributeValue::N(state.consecutive_successes.to_string()),
+            )
+            .item(
+                "opened_at",
+                match state.opened_at {
+                    Some(ts) => AttributeValue::N(ts.to_string()),
+                    None => AttributeValue::Null(true),
+                },
+            )
+            .item(
+                "next_probe_at",
+                match state.next_probe_at {
+                    Some(ts) => AttributeValue::N(ts.to_string()),
+                    None => AttributeValue::Null(true),
+                },
+            )
+            .item(
+                "last_failure_at",
+                match state.last_failure_at {
+                    Some(ts) => AttributeValue::N(ts.to_string()),
+                    None => AttributeValue::Null(true),
+                },
+            )
+            .item(
+                "last_success_at",
+                match state.last_success_at {
+                    Some(ts) => AttributeValue::N(ts.to_string()),
+                    None => AttributeValue::Null(true),
+                },
+            )
+            .item(
+                "half_open_in_flight",
+                AttributeValue::Bool(state.half_open_in_flight),
+            )
+            .item("version", AttributeValue::N(state.version.to_string()))
+            .send()
+            .await
+            .map_err(|e| WorkerError::DynamoDb(format!("failed to put breaker state: {e}")))?;
+        info!("put breaker state");
+        Ok(())
+    }
+}
+
+fn parse_breaker_state_item(
+    item: HashMap<String, AttributeValue>,
+) -> Result<BreakerState, WorkerError> {
+    Ok(BreakerState {
+        endpoint_key: get_string_attr(required_attr(&item, "endpoint_key")?)?,
+        mode: parse_breaker_mode_attr(required_attr(&item, "mode")?)?,
+        consecutive_failures: get_number_attr(required_attr(&item, "consecutive_failures")?)?
+            as u32,
+        consecutive_successes: get_number_attr(required_attr(&item, "consecutive_successes")?)?
+            as u32,
+        opened_at: optional_number_attr(&item, "opened_at")?,
+        next_probe_at: optional_number_attr(&item, "next_probe_at")?,
+        last_failure_at: optional_number_attr(&item, "last_failure_at")?,
+        last_success_at: optional_number_attr(&item, "last_success_at")?,
+        half_open_in_flight: get_bool_attr(required_attr(&item, "half_open_in_flight")?)?,
+        version: optional_number_attr(&item, "version")?.unwrap_or(0) as u64,
+    })
+}
+
+fn parse_breaker_mode_attr(attr: &AttributeValue) -> Result<BreakerMode, WorkerError> {
+    if let AttributeValue::S(s) = attr {
+        match s.as_str() {
+            "closed" => Ok(BreakerMode::Closed),
+            "open" => Ok(BreakerMode::Open),
+            "half_open" => Ok(BreakerMode::HalfOpen),
+            _ => Err(WorkerError::DecodeDynamo(format!(
+                "Invalid breaker mode value: {}",
+                s
+            ))),
+        }
+    } else {
+        Err(WorkerError::DecodeDynamo(
+            "Expected string attribute for breaker mode".to_string(),
+        ))
     }
 }
 
@@ -480,6 +652,7 @@ mod tests {
     async fn validates_attempt_recording_and_event_updates() {
         let events_table = must_env("WEBHOOK_EVENTS_TABLE");
         let configs_table = must_env("WEBHOOK_CONFIGS_TABLE");
+        let breaker_states_table = must_env("BREAKER_STATES_TABLE");
         let _region = must_env("AWS_REGION");
         let ts_now = now_unix_secs();
         let unique = format!(
@@ -496,8 +669,12 @@ mod tests {
 
         let shared_config = aws_config::load_defaults(BehaviorVersion::latest()).await;
         let client = Client::new(&shared_config);
-        let service =
-            DynamoDbService::new(client.clone(), events_table.clone(), configs_table.clone());
+        let service = DynamoDbService::new(
+            client.clone(),
+            events_table.clone(),
+            configs_table.clone(),
+            breaker_states_table.clone(),
+        );
         let mut cleanup = CleanupGuard::new(client.clone());
 
         client

--- a/worker/src/services/dynamodb.rs
+++ b/worker/src/services/dynamodb.rs
@@ -380,10 +380,7 @@ impl DynamoDbService {
                 AttributeValue::S(BreakerState::pk(endpoint_key.to_string())),
             )
             .item("sk", AttributeValue::S(BreakerState::sk().to_string()))
-            .item(
-                "endpoint_key",
-                AttributeValue::S(endpoint_key.to_string()),
-            )
+            .item("endpoint_key", AttributeValue::S(endpoint_key.to_string()))
             .item(
                 "mode",
                 AttributeValue::S(


### PR DESCRIPTION
## Summary
- add shared delivery error taxonomy and policy mapping updates in worker flow
- close out resilience metrics wiring (breaker transitions, retry/visibility, DLQ replay)
- persist breaker state in DynamoDB with optimistic version checks
- add `webhook_breaker_states` table and wire env/IAM in `template.yaml`
- wire `BREAKER_STATES_TABLE` through worker bootstrap and DynamoDbService
- patch ECS deploy assets to include breaker table env, ARM64 runtime, and safer defaults
- update ECS worker policy template and README examples

## Validation
- `cargo test -p worker` (24 passed, 1 ignored)
- `sam validate --template template.yaml --region us-west-2`

## Notes
- stack deployment should use built artifacts (`sam build` then deploy `.aws-sam/build/template.yaml`) to avoid Lambda package-size issues when deploying from repo root.
