### PR TITLE
Day 8 Closeout: DLQ ops workflow, runbooks, and scenario suite

### DIFF
--- a/docs/ENGINEER_2_TIMELINE.md
+++ b/docs/ENGINEER_2_TIMELINE.md
@@ -288,26 +288,26 @@
   - Retryable network/transient failures (timeout, DNS/connect reset, 5xx, 429)
   - Non-retryable customer errors (most 4xx, invalid URL/signature expectations)
   - Internal/service errors (missing config/event, serialization/parse failures)
-- [ ] Add deterministic mapping from error class -> worker action:
+- [x] Add deterministic mapping from error class -> worker action:
   - `retry` (requeue with computed backoff)
   - `fail_terminal` (mark failed, no more retries)
   - `drop_invalid` (record attempt + diagnostic reason)
-- [ ] Implement deferred resilience hardening from Day 7:
+- [x] Implement deferred resilience hardening from Day 7:
   - Persist circuit-breaker state (open/half-open/closed) in DynamoDB
   - Load breaker state at worker boot and refresh during processing
 
 **Afternoon (1pm-5pm): DLQ Operations + Runbook**
-- [ ] Add DLQ processing utility/script in `scripts/`:
+- [x] Add DLQ processing utility/script in `scripts/`:
   - Poll and decode DLQ messages
   - Summarize root-cause buckets by error class
   - Support safe replay for selected message IDs (dry-run default)
 - [x] Emit resilience metrics:
   - `CircuitBreakerOpen`, `CircuitBreakerHalfOpen`, `CircuitBreakerClose`
   - `RetryDelayMs`, `VisibilityTimeoutSeconds`, `DlqReplayCount`
-- [ ] Write operator docs:
+- [x] Write operator docs:
   - `docs/runbook.md`: DLQ triage and replay steps
   - `docs/troubleshooting.md`: error-class playbook and escalation path
-- [ ] Run scenario tests:
+- [x] Run scenario tests:
   - Endpoint outage (5xx/timeouts)
   - Permanent 4xx failure
   - Missing/disabled config
@@ -441,8 +441,8 @@ By end of sprint, you should have:
 - [x] `worker/tests/end_to_end_test.sh` - Contract integration helper
 - [x] `scripts/e2e_ingestion_worker.sh` - Full ingestion->worker e2e
 - [x] `tests/test_dynamodb.sh` - DynamoDB tests
-- [ ] `docs/runbook.md` - Operational guide
-- [ ] `docs/troubleshooting.md` - Common issues
+- [x] `docs/runbook.md` - Operational guide
+- [x] `docs/troubleshooting.md` - Common issues
 - [ ] `README.md` - Worker overview
 
 ---

--- a/docs/WORKER_RUNTIME.md
+++ b/docs/WORKER_RUNTIME.md
@@ -158,6 +158,10 @@ Expected values:
   - task count remains at desired
   - no frequent task restarts
 
+## DLQ Operations
+
+For DLQ triage and replay workflow, see `docs/runbook.md`.
+
 ## Future Migration Note
 
 If moving to SQS-triggered Lambda later, refactor worker from infinite loop to per-batch/per-message Lambda handler first. Keep this runtime until that refactor is complete.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,212 @@
+# Operations Runbook
+
+## DLQ Triage and Replay (`scripts/dlq_ops.sh`)
+
+### Purpose
+
+Use `scripts/dlq_ops.sh` to:
+- inspect DLQ messages,
+- summarize root-cause buckets,
+- replay selected messages safely (dry-run by default).
+
+### Defaults
+
+The script defaults to dev settings:
+- `STACK_NAME=hooray-dev`
+- `AWS_REGION=us-west-2`
+- `AWS_PROFILE=hooray-dev`
+- `MODE=inspect`
+- `DRY_RUN=true`
+
+It auto-resolves `DLQ_URL`, `MAIN_QUEUE_URL`, and `EVENTS_TABLE` from CloudFormation stack outputs.
+
+### Inspect DLQ
+
+```bash
+MODE=inspect ./scripts/dlq_ops.sh
+```
+
+Output includes:
+- table of current batch (`MESSAGE_ID`, `EVENT_ID`, `ERROR_CLASS`, receive count),
+- root-cause bucket summary.
+
+### Replay (Safe Dry Run)
+
+```bash
+MODE=replay REPLAY_MESSAGE_IDS="id1,id2" DRY_RUN=true ./scripts/dlq_ops.sh
+```
+
+This validates candidate selection without sending or deleting anything.
+
+### Replay for Real (Keep DLQ Original)
+
+```bash
+MODE=replay REPLAY_MESSAGE_IDS="id1,id2" DRY_RUN=false ./scripts/dlq_ops.sh
+```
+
+This sends selected messages to the main queue and keeps original DLQ messages.
+
+### Replay and Delete from DLQ
+
+```bash
+MODE=replay REPLAY_MESSAGE_IDS="id1,id2" DRY_RUN=false DELETE_AFTER_REPLAY=true ./scripts/dlq_ops.sh
+```
+
+This sends selected messages to the main queue, then deletes them from DLQ.
+
+### Useful Overrides
+
+```bash
+STACK_NAME=hooray-dev \
+AWS_REGION=us-west-2 \
+AWS_PROFILE=hooray-dev \
+MAX_MESSAGES=10 \
+WAIT_TIME_SECS=2 \
+VISIBILITY_TIMEOUT_SECS=30 \
+MODE=inspect ./scripts/dlq_ops.sh
+```
+
+You can bypass stack output lookup by setting:
+- `DLQ_URL`
+- `MAIN_QUEUE_URL`
+- `EVENTS_TABLE`
+
+### Notes and Caveats
+
+- `REPLAY_MESSAGE_IDS` must exist in the script's current receive batch.
+- If IDs change between runs, rerun inspect and use current IDs.
+- The script uses temporary files in `/tmp` and cleans them via `trap`.
+
+## Preconditions Checklist
+
+- Confirm AWS login/session is valid:
+  - `aws sts get-caller-identity --profile "$AWS_PROFILE"`
+- Confirm target stack/environment:
+  - `STACK_NAME`, `AWS_REGION`, `AWS_PROFILE`
+- Confirm required outputs exist for the stack:
+  - `DLQUrl`, `QueueUrl`, `EventsTableName`
+- Confirm operator has permissions:
+  - `sqs:ReceiveMessage`, `sqs:DeleteMessage`, `sqs:SendMessage`
+  - `cloudformation:DescribeStacks`
+  - `dynamodb:Query`
+
+## Safety Protocol
+
+- Always run `MODE=inspect` first.
+- Always run replay with `DRY_RUN=true` before `DRY_RUN=false`.
+- Use `DELETE_AFTER_REPLAY=true` only after dry-run validation.
+- Prefer replaying a small set of IDs first, then verify outcomes before bulk replay.
+
+## DLQ Triage Decision Tree
+
+1. `error_class=unknown` and `event_id=unknown`:
+   - Likely malformed/legacy payload or parsing mismatch.
+   - Action: inspect raw message body; avoid bulk replay until understood.
+2. Retryable/transient classes (`http_server_error`, `network_*`, `http_rate_limited`):
+   - Action: replay after endpoint/service health is restored.
+3. Terminal classes (`http_client_error`, config missing/inactive):
+   - Action: fix customer config/payload issue first, then replay.
+4. Internal/storage classes (`dynamodb_error`, `sqs_error`, `internal_error`):
+   - Action: escalate to platform/infra owner before replaying at scale.
+
+## Verification After Replay
+
+- Confirm message sent to main queue:
+  - `aws sqs get-queue-attributes --queue-url "$MAIN_QUEUE_URL" --attribute-names ApproximateNumberOfMessages`
+- Confirm worker processed it (logs/metrics).
+- Confirm DynamoDB event state/attempt:
+  - `pk=EVENT#<event_id>, sk=v0`
+  - `pk=EVENT#<event_id>, sk=ATTEMPT#<n>`
+- Confirm DLQ depth trend after action:
+  - should decrease/stabilize, not continue climbing for same root cause.
+
+## Rollback and Containment
+
+- Stop further replay operations immediately if failures spike.
+- Keep `DELETE_AFTER_REPLAY=false` until successful verification.
+- Temporarily disable failing customer config if endpoint is unhealthy.
+- Scale worker cautiously only after confirming downstream endpoint capacity.
+
+## Incident Logging Template
+
+Record for each replay operation:
+- Timestamp (UTC)
+- Operator
+- Stack/region/profile
+- Message IDs / event IDs
+- Exact command run
+- Dry-run result and real replay result
+- Verification outcome
+- Follow-up owner and ETA
+
+## Batch Replay Playbook
+
+- Start with small batches (`MAX_MESSAGES=10` or less).
+- Replay in waves, verify between waves.
+- Avoid large bursts to prevent endpoint thundering herd.
+- Prefer oldest/highest receive-count items first.
+
+## Known Limitations
+
+- Replay selection is based on IDs from the current receive batch.
+- IDs may rotate between runs due to visibility timing.
+- `event_id` can appear as `unknown` for bodies that do not match expected decode path.
+
+## Escalation Path
+
+- Platform/Infra owner:
+  - AWS permission issues, stack/output mismatches, queue anomalies.
+- Delivery worker owner:
+  - classification mismatches, replay script issues, worker processing failures.
+- Customer integration owner:
+  - persistent endpoint 4xx/5xx due to customer-side issues.
+
+## Command Cookbook
+
+Inspect:
+```bash
+MODE=inspect ./scripts/dlq_ops.sh
+```
+
+Dry-run replay for one ID:
+```bash
+MODE=replay REPLAY_MESSAGE_IDS="id1" DRY_RUN=true ./scripts/dlq_ops.sh
+```
+
+Replay one ID (keep in DLQ):
+```bash
+MODE=replay REPLAY_MESSAGE_IDS="id1" DRY_RUN=false ./scripts/dlq_ops.sh
+```
+
+Replay and delete from DLQ:
+```bash
+MODE=replay REPLAY_MESSAGE_IDS="id1" DRY_RUN=false DELETE_AFTER_REPLAY=true ./scripts/dlq_ops.sh
+```
+
+Inspect with explicit stack/profile/region:
+```bash
+STACK_NAME=hooray-dev AWS_PROFILE=hooray-dev AWS_REGION=us-west-2 MODE=inspect ./scripts/dlq_ops.sh
+```
+
+Run Day 8 scenario suite:
+```bash
+AWS_REGION=us-west-2 AWS_PROFILE=hooray-dev STACK_NAME=hooray-dev ./scripts/e2e_day8_dlq_ops.sh
+```
+
+Run Day 8 suite without long DLQ wait:
+```bash
+RUN_LONG_DLQ_SCENARIO=false ./scripts/e2e_day8_dlq_ops.sh
+```
+
+### Day 8 Scenario 4 Note (Long-Running)
+
+`Scenario 4` in `scripts/e2e_day8_dlq_ops.sh` validates:
+- endpoint outage (`5xx`) leads to message transition into DLQ.
+
+This is intentionally slower because DLQ redrive happens only after retry cycles.
+With current defaults (`SqsVisibilityTimeoutSeconds=60`, `SqsMaxReceiveCount=4`), this can take several minutes.
+
+Use fast mode when you only want non-DLQ-transition checks:
+```bash
+RUN_LONG_DLQ_SCENARIO=false ./scripts/e2e_day8_dlq_ops.sh
+```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,165 @@
+# Troubleshooting Guide
+
+## Scope
+
+This guide covers delivery-worker failures, DLQ triage, and escalation for webhook delivery incidents.
+
+Primary operational workflow:
+- Use [runbook.md](/Users/yizehu/Workspaces/HooRay-Relay/docs/runbook.md) for DLQ inspect/replay commands.
+- Use this document to classify issues and decide corrective action.
+
+## Quick Triage
+
+1. Check queue health:
+   - Main queue depth
+   - DLQ depth
+2. Check worker health:
+   - ECS service/task status
+   - worker logs for recent errors
+3. Classify failure:
+   - retryable transient
+   - terminal customer error
+   - internal/storage/platform error
+4. Apply action:
+   - fix root cause first
+   - replay from DLQ only after fix is verified
+
+## Symptom Playbooks
+
+### Worker not processing messages
+
+Checks:
+- ECS desired/running task count is healthy.
+- Worker logs show polling activity.
+- Worker has valid `QUEUE_URL`, `EVENTS_TABLE`, `CONFIGS_TABLE`, `BREAKER_STATES_TABLE`.
+- IAM for worker role includes SQS + DynamoDB access.
+
+Actions:
+- Restart/roll out worker task if unhealthy.
+- Fix env vars and redeploy task definition if misconfigured.
+- Fix IAM policy and re-run.
+
+Escalate to:
+- Platform/Infra owner if ECS/IAM/networking is broken.
+
+### High failure rate
+
+Checks:
+- Top error classes from logs/DLQ summary.
+- Recent HTTP statuses (4xx vs 5xx).
+- Endpoint availability/latency.
+
+Actions:
+- If mostly `http_server_error`/`network_*`: treat as transient; replay after endpoint recovery.
+- If mostly `http_client_error`: fix payload/config/URL expectations before replay.
+- If config-related (`config_missing`/inactive): fix config first.
+
+Escalate to:
+- Customer integration owner for persistent endpoint-side failures.
+
+### Queue backing up
+
+Checks:
+- Main queue visible/not-visible counts and trend.
+- Worker concurrency/capacity.
+- Downstream endpoint latency and error rate.
+
+Actions:
+- Remove blockers first (endpoint outage, config errors).
+- Scale worker conservatively only after downstream can absorb load.
+- Replay DLQ in waves after stabilization.
+
+Escalate to:
+- Platform/Infra owner if capacity/scaling constraints persist.
+
+### DLQ messages appearing repeatedly
+
+Checks:
+- Use `MODE=inspect ./scripts/dlq_ops.sh`.
+- Identify whether failures are transient, terminal, or internal.
+- Confirm whether same event/message is re-failing after replay.
+
+Actions:
+- Stop replay loop until root cause is fixed.
+- Replay with `DRY_RUN=true` first, then small real batch.
+- Use `DELETE_AFTER_REPLAY=true` only after successful verification.
+
+Escalate to:
+- Delivery worker owner for classification or script behavior mismatches.
+
+## Error-Class Playbook
+
+### Retryable / transient
+
+Classes:
+- `http_server_error`
+- `http_rate_limited`
+- `network_timeout`
+- `network_connect`
+- `network_request`
+- `dynamodb_error`
+- `sqs_error`
+
+Action:
+- Resolve transient cause, then replay from DLQ in small batches.
+
+### Terminal / customer fix required
+
+Classes:
+- `http_client_error`
+- `config_missing`
+- `config_inactive`
+- `transport_other` (case-by-case, often terminal)
+
+Action:
+- Fix payload/config/endpoint expectations first.
+- Replay only after corrective change is confirmed.
+
+### Invalid or malformed input
+
+Classes:
+- `invalid_queue_message`
+- `serialization_error`
+
+Action:
+- Inspect raw message format and producer contract.
+- Avoid bulk replay until message validity is confirmed.
+
+### Internal unknown
+
+Classes:
+- `internal_error`
+- `unknown` (from DLQ utility fallback)
+
+Action:
+- Investigate worker logs and DynamoDB attempt history.
+- Escalate before broad replay.
+
+## Verification Checklist After Any Replay
+
+- Main queue receives replayed messages.
+- Worker consumes and processes messages.
+- Event status transitions as expected in `webhook_events`.
+- Attempt rows are written (`ATTEMPT#n`).
+- DLQ depth decreases or stabilizes.
+- Failure rate does not spike again for same root cause.
+
+## Escalation Path
+
+- Platform/Infra owner:
+  - AWS access/policy issues, ECS instability, queue anomalies.
+- Delivery worker owner:
+  - worker logic, classification, breaker/retry behavior, replay script issues.
+- Customer integration owner:
+  - endpoint contract violations, persistent customer-side 4xx/5xx.
+
+## Incident Record (Minimum)
+
+- Incident start time (UTC)
+- Environment/stack/region
+- Affected message IDs and event IDs
+- Observed error classes
+- Commands/actions executed
+- Replay mode used (`dry-run`, delete or keep)
+- Outcome and verification evidence
+- Follow-up owner and ETA

--- a/scripts/dlq_ops.sh
+++ b/scripts/dlq_ops.sh
@@ -1,0 +1,333 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# DLQ operations utility:
+# - Poll + decode DLQ messages
+# - Summarize root-cause buckets by error class (from latest ATTEMPT#n in events table)
+# - Replay selected DLQ message IDs to main queue (dry-run by default)
+#
+# Defaults:
+# - MODE=inspect (inspect|replay)
+# - AWS_REGION=us-west-2
+# - AWS_PROFILE=hooray-dev
+# - STACK_NAME=hooray-dev
+# - MAX_MESSAGES=10
+# - WAIT_TIME_SECS=2
+# - VISIBILITY_TIMEOUT_SECS=30
+# - DRY_RUN=true
+# - REPLAY_MESSAGE_IDS="" (comma-separated SQS MessageId values)
+# - DELETE_AFTER_REPLAY=false
+#
+# Optional explicit overrides:
+# - DLQ_URL
+# - MAIN_QUEUE_URL
+# - EVENTS_TABLE
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "ERROR: required command not found: $cmd" >&2
+    exit 1
+  fi
+}
+
+require_cmd aws
+require_cmd jq
+
+MODE="${MODE:-inspect}"
+AWS_REGION="${AWS_REGION:-us-west-2}"
+AWS_PROFILE="${AWS_PROFILE:-hooray-dev}"
+STACK_NAME="${STACK_NAME:-hooray-dev}"
+MAX_MESSAGES="${MAX_MESSAGES:-10}"
+WAIT_TIME_SECS="${WAIT_TIME_SECS:-2}"
+VISIBILITY_TIMEOUT_SECS="${VISIBILITY_TIMEOUT_SECS:-30}"
+DRY_RUN="${DRY_RUN:-true}"
+REPLAY_MESSAGE_IDS="${REPLAY_MESSAGE_IDS:-}"
+DELETE_AFTER_REPLAY="${DELETE_AFTER_REPLAY:-false}"
+
+usage() {
+  cat <<USAGE
+Usage:
+  MODE=inspect ./scripts/dlq_ops.sh
+  MODE=replay REPLAY_MESSAGE_IDS="<msg-id-1>,<msg-id-2>" ./scripts/dlq_ops.sh
+
+Important env vars:
+  MODE=inspect|replay
+  DRY_RUN=true|false               (default true)
+  REPLAY_MESSAGE_IDS=...           (required for MODE=replay)
+  DELETE_AFTER_REPLAY=true|false   (default false)
+  DLQ_URL=...                      (optional; auto-resolved from stack)
+  MAIN_QUEUE_URL=...               (optional; auto-resolved from stack)
+  EVENTS_TABLE=...                 (optional; auto-resolved from stack)
+USAGE
+}
+
+if [[ "$MODE" != "inspect" && "$MODE" != "replay" ]]; then
+  echo "ERROR: MODE must be inspect or replay, got: $MODE" >&2
+  usage
+  exit 1
+fi
+
+resolve_from_stack_if_missing() {
+  if [[ -n "${DLQ_URL:-}" && -n "${MAIN_QUEUE_URL:-}" && -n "${EVENTS_TABLE:-}" ]]; then
+    return
+  fi
+
+  local outputs_json
+  outputs_json="$(aws cloudformation describe-stacks \
+    --stack-name "$STACK_NAME" \
+    --region "$AWS_REGION" \
+    --profile "$AWS_PROFILE" \
+    --query 'Stacks[0].Outputs' \
+    --output json)"
+
+  if [[ -z "${DLQ_URL:-}" ]]; then
+    DLQ_URL="$(echo "$outputs_json" | jq -r '.[] | select(.OutputKey=="DLQUrl") | .OutputValue')"
+  fi
+  if [[ -z "${MAIN_QUEUE_URL:-}" ]]; then
+    MAIN_QUEUE_URL="$(echo "$outputs_json" | jq -r '.[] | select(.OutputKey=="QueueUrl") | .OutputValue')"
+  fi
+  if [[ -z "${EVENTS_TABLE:-}" ]]; then
+    EVENTS_TABLE="$(echo "$outputs_json" | jq -r '.[] | select(.OutputKey=="EventsTableName") | .OutputValue')"
+  fi
+}
+
+resolve_from_stack_if_missing
+
+if [[ -z "${DLQ_URL:-}" || "$DLQ_URL" == "null" ]]; then
+  echo "ERROR: DLQ_URL is missing (set DLQ_URL or provide a stack with DLQUrl output)" >&2
+  exit 1
+fi
+if [[ -z "${MAIN_QUEUE_URL:-}" || "$MAIN_QUEUE_URL" == "null" ]]; then
+  echo "ERROR: MAIN_QUEUE_URL is missing (set MAIN_QUEUE_URL or provide a stack with QueueUrl output)" >&2
+  exit 1
+fi
+if [[ -z "${EVENTS_TABLE:-}" || "$EVENTS_TABLE" == "null" ]]; then
+  echo "ERROR: EVENTS_TABLE is missing (set EVENTS_TABLE or provide a stack with EventsTableName output)" >&2
+  exit 1
+fi
+
+if [[ "$MODE" == "replay" && -z "$REPLAY_MESSAGE_IDS" ]]; then
+  echo "ERROR: REPLAY_MESSAGE_IDS is required when MODE=replay" >&2
+  exit 1
+fi
+
+TMP_RAW="$(mktemp "${TMPDIR:-/tmp}/dlq_ops.raw.XXXXXX.json")"
+TMP_ENRICHED="$(mktemp "${TMPDIR:-/tmp}/dlq_ops.enriched.XXXXXX.ndjson")"
+cleanup() {
+  rm -f "$TMP_RAW" "$TMP_ENRICHED"
+}
+trap cleanup EXIT INT TERM
+
+aws sqs receive-message \
+  --queue-url "$DLQ_URL" \
+  --region "$AWS_REGION" \
+  --profile "$AWS_PROFILE" \
+  --max-number-of-messages "$MAX_MESSAGES" \
+  --wait-time-seconds "$WAIT_TIME_SECS" \
+  --visibility-timeout "$VISIBILITY_TIMEOUT_SECS" \
+  --attribute-names All \
+  --message-attribute-names All \
+  --output json > "$TMP_RAW"
+
+message_count="$(jq '.Messages | length // 0' "$TMP_RAW")"
+if [[ "$message_count" -eq 0 ]]; then
+  echo "No messages received from DLQ: $DLQ_URL"
+  exit 0
+fi
+
+echo "Received $message_count DLQ messages"
+
+jq -c '.Messages[]' "$TMP_RAW" | while IFS= read -r msg; do
+  message_id="$(echo "$msg" | jq -r '.MessageId')"
+  receipt_handle="$(echo "$msg" | jq -r '.ReceiptHandle')"
+  body_raw="$(echo "$msg" | jq -r '.Body // ""')"
+
+  event_id="$(echo "$msg" | jq -r '
+    .Body as $b
+    | ($b | fromjson? // $b) as $decoded
+    | if ($decoded | type) == "object" then
+        ($decoded.event_id // empty)
+      elif ($decoded | type) == "string" then
+        (($decoded | fromjson? // {}) | .event_id // empty)
+      else
+        empty
+      end
+  ' 2>/dev/null || true)"
+  if [[ -z "$event_id" ]]; then
+    event_id="unknown"
+  fi
+
+  receive_count="$(echo "$msg" | jq -r '.Attributes.ApproximateReceiveCount // "unknown"')"
+  first_received_at_ms="$(echo "$msg" | jq -r '.Attributes.ApproximateFirstReceiveTimestamp // ""')"
+
+  error_class="unknown"
+  last_error_message=""
+
+  if [[ "$event_id" != "unknown" ]]; then
+    attempt_items="$(aws dynamodb query \
+      --region "$AWS_REGION" \
+      --profile "$AWS_PROFILE" \
+      --table-name "$EVENTS_TABLE" \
+      --key-condition-expression 'pk = :pk AND begins_with(sk, :prefix)' \
+      --expression-attribute-values "{\":pk\":{\"S\":\"EVENT#${event_id}\"},\":prefix\":{\"S\":\"ATTEMPT#\"}}" \
+      --projection-expression 'attempt_number,error_message,sk' \
+      --output json 2>/dev/null || true)"
+
+    if [[ -n "$attempt_items" ]]; then
+      latest_error="$(echo "$attempt_items" | jq -r '
+        .Items
+        | map({
+            attempt_number: ((.attempt_number.N // "0") | tonumber),
+            error_message: (.error_message.S // "")
+          })
+        | sort_by(.attempt_number)
+        | last
+        | .error_message // ""
+      ' 2>/dev/null || true)"
+
+      if [[ -n "$latest_error" ]]; then
+        last_error_message="$latest_error"
+        parsed_class="$(echo "$latest_error" | sed -n 's/^\[\([^]]\+\)\].*/\1/p')"
+        if [[ -n "$parsed_class" ]]; then
+          error_class="$parsed_class"
+        else
+          lowered_error="$(echo "$latest_error" | tr '[:upper:]' '[:lower:]')"
+          if [[ "$lowered_error" == *"http 429"* || "$lowered_error" == *"rate limit"* ]]; then
+            error_class="http_rate_limited"
+          elif [[ "$lowered_error" == *"http 5"* ]]; then
+            error_class="http_server_error"
+          elif [[ "$lowered_error" == *"http 4"* ]]; then
+            error_class="http_client_error"
+          elif [[ "$lowered_error" == *"timeout"* ]]; then
+            error_class="network_timeout"
+          elif [[ "$lowered_error" == *"connect"* || "$lowered_error" == *"connection reset"* || "$lowered_error" == *"connection refused"* ]]; then
+            error_class="network_connect"
+          elif [[ "$lowered_error" == *"dns"* || "$lowered_error" == *"resolve"* || "$lowered_error" == *"name or service not known"* ]]; then
+            error_class="network_request"
+          else
+            error_class="unclassified"
+          fi
+        fi
+      else
+        error_class="no_attempt_error"
+      fi
+    fi
+  fi
+
+  jq -cn \
+    --arg message_id "$message_id" \
+    --arg receipt_handle "$receipt_handle" \
+    --arg event_id "$event_id" \
+    --arg error_class "$error_class" \
+    --arg error_message "$last_error_message" \
+    --arg receive_count "$receive_count" \
+    --arg first_received_at_ms "$first_received_at_ms" \
+    --arg body "$body_raw" \
+    '{
+      message_id: $message_id,
+      event_id: $event_id,
+      error_class: $error_class,
+      last_error_message: $error_message,
+      receive_count: $receive_count,
+      first_received_at_ms: $first_received_at_ms,
+      body: $body,
+      receipt_handle: $receipt_handle
+    }' >> "$TMP_ENRICHED"
+
+done
+
+echo
+printf '%-36s %-28s %-24s %-8s\n' "MESSAGE_ID" "EVENT_ID" "ERROR_CLASS" "RECV"
+printf '%-36s %-28s %-24s %-8s\n' "----------" "--------" "-----------" "----"
+while IFS= read -r row; do
+  message_id="$(echo "$row" | jq -r '.message_id')"
+  event_id="$(echo "$row" | jq -r '.event_id')"
+  error_class="$(echo "$row" | jq -r '.error_class')"
+  receive_count="$(echo "$row" | jq -r '.receive_count')"
+  printf '%-36s %-28s %-24s %-8s\n' "$message_id" "$event_id" "$error_class" "$receive_count"
+done < "$TMP_ENRICHED"
+
+echo
+echo "Root-cause bucket summary"
+jq -s '
+  group_by(.error_class)
+  | map({error_class: .[0].error_class, count: length})
+  | sort_by(-.count)
+' "$TMP_ENRICHED"
+
+if [[ "$MODE" == "inspect" ]]; then
+  echo
+  echo "Inspect mode only. No replay performed."
+  echo "Tip: MODE=replay REPLAY_MESSAGE_IDS=\"id1,id2\" DRY_RUN=true ./scripts/dlq_ops.sh"
+  exit 0
+fi
+
+selected_json="$(jq -n --arg ids "$REPLAY_MESSAGE_IDS" '$ids | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))')"
+selected_count="$(echo "$selected_json" | jq 'length')"
+if [[ "$selected_count" -eq 0 ]]; then
+  echo "ERROR: no valid IDs parsed from REPLAY_MESSAGE_IDS" >&2
+  exit 1
+fi
+
+echo
+echo "Replay candidates"
+replay_rows="$(jq -s --argjson ids "$selected_json" '
+  map(select(.message_id as $id | $ids | index($id)))
+  | sort_by(.message_id)
+  | group_by(.message_id)
+  | map(.[0])
+' "$TMP_ENRICHED")"
+
+found_count="$(echo "$replay_rows" | jq 'length')"
+if [[ "$found_count" -eq 0 ]]; then
+  echo "ERROR: none of REPLAY_MESSAGE_IDS are present in the current receive batch" >&2
+  echo "Hint: increase MAX_MESSAGES or rerun to fetch more DLQ messages" >&2
+  exit 1
+fi
+
+echo "$replay_rows" | jq
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo
+  echo "DRY_RUN=true: no messages sent and nothing deleted."
+  exit 0
+fi
+
+echo
+for idx in $(seq 0 $((found_count - 1))); do
+  row="$(echo "$replay_rows" | jq ".[$idx]")"
+  message_id="$(echo "$row" | jq -r '.message_id')"
+  event_id="$(echo "$row" | jq -r '.event_id')"
+  receipt_handle="$(echo "$row" | jq -r '.receipt_handle')"
+  body="$(echo "$row" | jq -r '.body')"
+
+  # Mark replay path for worker metrics/diagnostics.
+  replay_attributes='{"dlq_replay":{"DataType":"String","StringValue":"true"}}'
+
+  aws sqs send-message \
+    --queue-url "$MAIN_QUEUE_URL" \
+    --region "$AWS_REGION" \
+    --profile "$AWS_PROFILE" \
+    --message-body "$body" \
+    --message-attributes "$replay_attributes" \
+    --output json >/dev/null
+
+  echo "Replayed message_id=$message_id event_id=$event_id to main queue"
+
+  if [[ "$DELETE_AFTER_REPLAY" == "true" ]]; then
+    aws sqs delete-message \
+      --queue-url "$DLQ_URL" \
+      --region "$AWS_REGION" \
+      --profile "$AWS_PROFILE" \
+      --receipt-handle "$receipt_handle" >/dev/null
+    echo "Deleted message_id=$message_id from DLQ"
+  fi
+done
+
+echo
+if [[ "$DELETE_AFTER_REPLAY" == "true" ]]; then
+  echo "Replay complete. Selected messages were sent to main queue and deleted from DLQ."
+else
+  echo "Replay complete. Selected messages were sent to main queue. DLQ originals were kept (DELETE_AFTER_REPLAY=false)."
+fi

--- a/scripts/e2e_day8_dlq_ops.sh
+++ b/scripts/e2e_day8_dlq_ops.sh
@@ -1,0 +1,455 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Day 8 scenario test suite: error handling + DLQ ops.
+#
+# Scenarios:
+# 1) Endpoint outage (5xx) -> message should transition to DLQ (long-running)
+# 2) Permanent 4xx -> event should transition to failed
+# 3) Missing config -> event should transition to failed
+# 4) Disabled config -> event should transition to failed
+# 5) DLQ replay workflow -> dry-run + real replay via scripts/dlq_ops.sh
+#
+# Defaults:
+# - AWS_REGION=us-west-2
+# - AWS_PROFILE=hooray-dev
+# - STACK_NAME=hooray-dev
+# - POLL_TIMEOUT_SECS=240
+# - POLL_INTERVAL_SECS=5
+# - DLQ_WAIT_TIMEOUT_SECS=480
+# - DLQ_WAIT_INTERVAL_SECS=10
+# - RUN_LONG_DLQ_SCENARIO=true
+# - RUN_REPLAY_VALIDATION=true
+# - DELETE_AFTER_REPLAY=false
+# - KEEP_TEST_DATA=false
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "ERROR: required command not found: $cmd" >&2
+    exit 1
+  fi
+}
+
+require_cmd aws
+require_cmd jq
+require_cmd curl
+require_cmd bash
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+
+AWS_REGION="${AWS_REGION:-us-west-2}"
+AWS_PROFILE="${AWS_PROFILE:-hooray-dev}"
+STACK_NAME="${STACK_NAME:-hooray-dev}"
+POLL_TIMEOUT_SECS="${POLL_TIMEOUT_SECS:-240}"
+POLL_INTERVAL_SECS="${POLL_INTERVAL_SECS:-5}"
+DLQ_WAIT_TIMEOUT_SECS="${DLQ_WAIT_TIMEOUT_SECS:-480}"
+DLQ_WAIT_INTERVAL_SECS="${DLQ_WAIT_INTERVAL_SECS:-10}"
+RUN_LONG_DLQ_SCENARIO="${RUN_LONG_DLQ_SCENARIO:-true}"
+RUN_REPLAY_VALIDATION="${RUN_REPLAY_VALIDATION:-true}"
+DELETE_AFTER_REPLAY="${DELETE_AFTER_REPLAY:-false}"
+KEEP_TEST_DATA="${KEEP_TEST_DATA:-false}"
+
+STACK_OUTPUTS_JSON="$(aws cloudformation describe-stacks \
+  --stack-name "$STACK_NAME" \
+  --region "$AWS_REGION" \
+  --profile "$AWS_PROFILE" \
+  --query "Stacks[0].Outputs" \
+  --output json)"
+
+API_URL="$(echo "$STACK_OUTPUTS_JSON" | jq -r '.[] | select(.OutputKey=="IngestionApiUrl") | .OutputValue')"
+EVENTS_TABLE="$(echo "$STACK_OUTPUTS_JSON" | jq -r '.[] | select(.OutputKey=="EventsTableName") | .OutputValue')"
+CONFIGS_TABLE="$(echo "$STACK_OUTPUTS_JSON" | jq -r '.[] | select(.OutputKey=="ConfigsTableName") | .OutputValue')"
+IDEMPOTENCY_TABLE="$(echo "$STACK_OUTPUTS_JSON" | jq -r '.[] | select(.OutputKey=="IdempotencyTableName") | .OutputValue')"
+QUEUE_URL="$(echo "$STACK_OUTPUTS_JSON" | jq -r '.[] | select(.OutputKey=="QueueUrl") | .OutputValue')"
+DLQ_URL="$(echo "$STACK_OUTPUTS_JSON" | jq -r '.[] | select(.OutputKey=="DLQUrl") | .OutputValue')"
+
+if [[ -z "$API_URL" || "$API_URL" == "null" || -z "$EVENTS_TABLE" || "$EVENTS_TABLE" == "null" || -z "$CONFIGS_TABLE" || "$CONFIGS_TABLE" == "null" || -z "$QUEUE_URL" || "$QUEUE_URL" == "null" || -z "$DLQ_URL" || "$DLQ_URL" == "null" ]]; then
+  echo "ERROR: missing required stack outputs (API_URL/EVENTS_TABLE/CONFIGS_TABLE/QUEUE_URL/DLQ_URL)" >&2
+  exit 1
+fi
+
+if [[ -z "$IDEMPOTENCY_TABLE" || "$IDEMPOTENCY_TABLE" == "null" ]]; then
+  echo "WARN: IdempotencyTableName output missing; cleanup for idempotency keys will be skipped"
+fi
+
+declare -a CLEANUP_EVENT_IDS=()
+declare -a CLEANUP_CUSTOMER_IDS=()
+declare -a CLEANUP_IDEMPOTENCY_KEYS=()
+
+cleanup() {
+  local exit_code=$?
+  set +e
+
+  if [[ "$KEEP_TEST_DATA" == "true" ]]; then
+    echo "[CLEANUP] KEEP_TEST_DATA=true, skipping cleanup"
+    return "$exit_code"
+  fi
+
+  for event_id in "${CLEANUP_EVENT_IDS[@]}"; do
+    local event_pk="EVENT#${event_id}"
+    aws dynamodb delete-item \
+      --region "$AWS_REGION" \
+      --profile "$AWS_PROFILE" \
+      --table-name "$EVENTS_TABLE" \
+      --key "{\"pk\":{\"S\":\"${event_pk}\"},\"sk\":{\"S\":\"ATTEMPT#1\"}}" >/dev/null 2>&1 || true
+    aws dynamodb delete-item \
+      --region "$AWS_REGION" \
+      --profile "$AWS_PROFILE" \
+      --table-name "$EVENTS_TABLE" \
+      --key "{\"pk\":{\"S\":\"${event_pk}\"},\"sk\":{\"S\":\"v0\"}}" >/dev/null 2>&1 || true
+  done
+
+  for customer_id in "${CLEANUP_CUSTOMER_IDS[@]}"; do
+    aws dynamodb delete-item \
+      --region "$AWS_REGION" \
+      --profile "$AWS_PROFILE" \
+      --table-name "$CONFIGS_TABLE" \
+      --key "{\"pk\":{\"S\":\"CUSTOMER#${customer_id}\"},\"sk\":{\"S\":\"CONFIG\"}}" >/dev/null 2>&1 || true
+  done
+
+  if [[ -n "$IDEMPOTENCY_TABLE" && "$IDEMPOTENCY_TABLE" != "null" ]]; then
+    for idem_key in "${CLEANUP_IDEMPOTENCY_KEYS[@]}"; do
+      aws dynamodb delete-item \
+        --region "$AWS_REGION" \
+        --profile "$AWS_PROFILE" \
+        --table-name "$IDEMPOTENCY_TABLE" \
+        --key "{\"pk\":{\"S\":\"IDEM#${idem_key}\"}}" >/dev/null 2>&1 || true
+    done
+  fi
+
+  return "$exit_code"
+}
+
+trap cleanup EXIT INT TERM
+
+ts_now() {
+  date +%s
+}
+
+unique_suffix() {
+  printf '%s_%s' "$(date +%s)" "$(date +%s%N | tail -c 7)"
+}
+
+add_cleanup_event() {
+  CLEANUP_EVENT_IDS+=("$1")
+}
+
+add_cleanup_customer() {
+  CLEANUP_CUSTOMER_IDS+=("$1")
+}
+
+add_cleanup_idem() {
+  CLEANUP_IDEMPOTENCY_KEYS+=("$1")
+}
+
+create_config_via_api() {
+  local customer_id="$1"
+  local delivery_url="$2"
+  local delivery_secret="$3"
+
+  local code
+  code="$(curl -sS -o /tmp/day8_config_resp.json -w "%{http_code}" \
+    -X POST "${API_URL}webhooks/configs" \
+    -H 'content-type: application/json' \
+    -d "{\"customer_id\":\"${customer_id}\",\"url\":\"${delivery_url}\",\"secret\":\"${delivery_secret}\"}")"
+
+  if [[ "$code" != "200" && "$code" != "201" ]]; then
+    echo "ERROR: failed to create config (status=${code}) for ${customer_id}" >&2
+    cat /tmp/day8_config_resp.json >&2
+    exit 1
+  fi
+}
+
+send_event_via_api() {
+  local customer_id="$1"
+  local idempotency_key="$2"
+  local payload_source="$3"
+
+  local code
+  code="$(curl -sS -o /tmp/day8_receive_resp.json -w "%{http_code}" \
+    -X POST "${API_URL}webhooks/receive" \
+    -H 'content-type: application/json' \
+    -d "{\"idempotency_key\":\"${idempotency_key}\",\"customer_id\":\"${customer_id}\",\"data\":{\"source\":\"${payload_source}\"}}")"
+
+  if [[ "$code" != "200" && "$code" != "202" ]]; then
+    echo "ERROR: failed to submit event (status=${code}) for customer=${customer_id}" >&2
+    cat /tmp/day8_receive_resp.json >&2
+    exit 1
+  fi
+
+  local event_id
+  event_id="$(jq -r '.event_id // empty' /tmp/day8_receive_resp.json)"
+  if [[ -z "$event_id" || "$event_id" == "null" ]]; then
+    echo "ERROR: missing event_id in ingestion response" >&2
+    cat /tmp/day8_receive_resp.json >&2
+    exit 1
+  fi
+
+  echo "$event_id"
+}
+
+seed_event_and_enqueue() {
+  local event_id="$1"
+  local customer_id="$2"
+  local payload_raw="$3"
+
+  local now
+  now="$(ts_now)"
+  local item_json
+  item_json="$(jq -cn \
+    --arg event_id "$event_id" \
+    --arg customer_id "$customer_id" \
+    --arg payload "$payload_raw" \
+    --arg now "$now" \
+    '{
+      pk:{S:("EVENT#" + $event_id)},
+      sk:{S:"v0"},
+      event_id:{S:$event_id},
+      customer_id:{S:$customer_id},
+      payload:{S:$payload},
+      status:{S:"pending"},
+      attempt_count:{N:"0"},
+      created_at:{N:$now}
+    }'
+  )"
+
+  aws dynamodb put-item \
+    --region "$AWS_REGION" \
+    --profile "$AWS_PROFILE" \
+    --table-name "$EVENTS_TABLE" \
+    --condition-expression "attribute_not_exists(pk) AND attribute_not_exists(sk)" \
+    --item "$item_json" >/dev/null
+
+  aws sqs send-message \
+    --region "$AWS_REGION" \
+    --profile "$AWS_PROFILE" \
+    --queue-url "$QUEUE_URL" \
+    --message-body "{\"event_id\":\"${event_id}\"}" \
+    --message-attributes "{\"customer_id\":{\"DataType\":\"String\",\"StringValue\":\"${customer_id}\"}}" >/dev/null
+}
+
+wait_for_event_status() {
+  local event_id="$1"
+  local expected_status="$2"
+  local timeout_secs="$3"
+
+  local event_pk="EVENT#${event_id}"
+  local deadline=$(( $(ts_now) + timeout_secs ))
+  local status=""
+
+  while [[ "$(ts_now)" -lt "$deadline" ]]; do
+    status="$(aws dynamodb get-item \
+      --region "$AWS_REGION" \
+      --profile "$AWS_PROFILE" \
+      --table-name "$EVENTS_TABLE" \
+      --key "{\"pk\":{\"S\":\"${event_pk}\"},\"sk\":{\"S\":\"v0\"}}" \
+      --query 'Item.status.S' \
+      --output text 2>/dev/null || true)"
+
+    if [[ "$status" == "$expected_status" ]]; then
+      echo "$status"
+      return 0
+    fi
+    sleep "$POLL_INTERVAL_SECS"
+  done
+
+  echo "$status"
+  return 1
+}
+
+wait_for_dlq_event_id() {
+  local event_id="$1"
+  local timeout_secs="$2"
+
+  local deadline=$(( $(ts_now) + timeout_secs ))
+  while [[ "$(ts_now)" -lt "$deadline" ]]; do
+    local msgs_json
+    msgs_json="$(aws sqs receive-message \
+      --region "$AWS_REGION" \
+      --profile "$AWS_PROFILE" \
+      --queue-url "$DLQ_URL" \
+      --max-number-of-messages 10 \
+      --wait-time-seconds 2 \
+      --visibility-timeout 1 \
+      --attribute-names All \
+      --message-attribute-names All \
+      --output json 2>/dev/null || true)"
+
+    local found
+    found="$(echo "$msgs_json" | jq -r --arg event_id "$event_id" '
+      (.Messages // [])
+      | map(.Body // "")
+      | map((fromjson? // {}) | .event_id // empty)
+      | any(. == $event_id)
+    ' 2>/dev/null || echo false)"
+
+    if [[ "$found" == "true" ]]; then
+      return 0
+    fi
+
+    sleep "$DLQ_WAIT_INTERVAL_SECS"
+  done
+
+  return 1
+}
+
+echo "[1/5] Scenario: permanent 4xx -> terminal failed"
+{
+  scenario_suffix="$(unique_suffix)"
+  customer_id="cust_day8_4xx_${scenario_suffix}"
+  idem_key="req_day8_4xx_${scenario_suffix}"
+  create_config_via_api "$customer_id" "https://httpbin.org/status/404" "whsec_day8_4xx"
+  add_cleanup_customer "$customer_id"
+  add_cleanup_idem "$idem_key"
+
+  event_id="$(send_event_via_api "$customer_id" "$idem_key" "day8-permanent-4xx")"
+  add_cleanup_event "$event_id"
+
+  if wait_for_event_status "$event_id" "failed" "$POLL_TIMEOUT_SECS" >/dev/null; then
+    echo "  - PASS: event ${event_id} transitioned to failed"
+  else
+    echo "ERROR: event ${event_id} did not transition to failed in time" >&2
+    exit 1
+  fi
+}
+
+echo "[2/5] Scenario: missing config -> terminal failed"
+{
+  scenario_suffix="$(unique_suffix)"
+  event_id="evt_day8_missing_cfg_${scenario_suffix}"
+  customer_id="cust_day8_missing_cfg_${scenario_suffix}"
+  payload_raw='{"source":"day8-missing-config"}'
+
+  seed_event_and_enqueue "$event_id" "$customer_id" "$payload_raw"
+  add_cleanup_event "$event_id"
+
+  if wait_for_event_status "$event_id" "failed" "$POLL_TIMEOUT_SECS" >/dev/null; then
+    echo "  - PASS: missing config event ${event_id} transitioned to failed"
+  else
+    echo "ERROR: missing config event ${event_id} did not transition to failed in time" >&2
+    exit 1
+  fi
+}
+
+echo "[3/5] Scenario: disabled config -> terminal failed"
+{
+  scenario_suffix="$(unique_suffix)"
+  event_id="evt_day8_disabled_cfg_${scenario_suffix}"
+  customer_id="cust_day8_disabled_cfg_${scenario_suffix}"
+  now="$(ts_now)"
+  payload_raw='{"source":"day8-disabled-config"}'
+
+  aws dynamodb put-item \
+    --region "$AWS_REGION" \
+    --profile "$AWS_PROFILE" \
+    --table-name "$CONFIGS_TABLE" \
+    --condition-expression "attribute_not_exists(pk) AND attribute_not_exists(sk)" \
+    --item "{
+      \"pk\":{\"S\":\"CUSTOMER#${customer_id}\"},
+      \"sk\":{\"S\":\"CONFIG\"},
+      \"customer_id\":{\"S\":\"${customer_id}\"},
+      \"url\":{\"S\":\"https://httpbin.org/post\"},
+      \"secret\":{\"S\":\"whsec_day8_disabled\"},
+      \"max_retries\":{\"N\":\"3\"},
+      \"active\":{\"BOOL\":false},
+      \"created_at\":{\"N\":\"${now}\"},
+      \"updated_at\":{\"N\":\"${now}\"}
+    }" >/dev/null
+
+  add_cleanup_customer "$customer_id"
+  seed_event_and_enqueue "$event_id" "$customer_id" "$payload_raw"
+  add_cleanup_event "$event_id"
+
+  if wait_for_event_status "$event_id" "failed" "$POLL_TIMEOUT_SECS" >/dev/null; then
+    echo "  - PASS: disabled config event ${event_id} transitioned to failed"
+  else
+    echo "ERROR: disabled config event ${event_id} did not transition to failed in time" >&2
+    exit 1
+  fi
+}
+
+if [[ "$RUN_LONG_DLQ_SCENARIO" == "true" ]]; then
+  echo "[4/5] Scenario: outage 5xx -> transition to DLQ (long-running)"
+  scenario_suffix="$(unique_suffix)"
+  customer_id="cust_day8_dlq_${scenario_suffix}"
+  idem_key="req_day8_dlq_${scenario_suffix}"
+  create_config_via_api "$customer_id" "https://httpbin.org/status/503" "whsec_day8_dlq"
+  add_cleanup_customer "$customer_id"
+  add_cleanup_idem "$idem_key"
+
+  outage_event_id="$(send_event_via_api "$customer_id" "$idem_key" "day8-outage-503")"
+  add_cleanup_event "$outage_event_id"
+
+  if wait_for_dlq_event_id "$outage_event_id" "$DLQ_WAIT_TIMEOUT_SECS"; then
+    echo "  - PASS: outage event ${outage_event_id} observed in DLQ"
+  else
+    echo "ERROR: outage event ${outage_event_id} not observed in DLQ within timeout=${DLQ_WAIT_TIMEOUT_SECS}s" >&2
+    exit 1
+  fi
+else
+  echo "[4/5] Skipped long DLQ scenario (RUN_LONG_DLQ_SCENARIO=false)"
+fi
+
+if [[ "$RUN_REPLAY_VALIDATION" == "true" ]]; then
+  echo "[5/5] Scenario: validate replay flow via dlq_ops.sh"
+  replay_ids=""
+  replay_match=false
+  for attempt in 1 2 3 4 5; do
+    inspect_out="$(MODE=inspect MAX_MESSAGES=10 VISIBILITY_TIMEOUT_SECS=0 AWS_REGION="$AWS_REGION" AWS_PROFILE="$AWS_PROFILE" STACK_NAME="$STACK_NAME" "$REPO_ROOT/scripts/dlq_ops.sh")"
+    echo "$inspect_out"
+
+    ids_from_inspect="$(echo "$inspect_out" | grep -Eo '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' | sort -u | paste -sd, -)"
+    if [[ -z "$ids_from_inspect" ]]; then
+      continue
+    fi
+
+    if [[ -z "$replay_ids" ]]; then
+      replay_ids="$ids_from_inspect"
+    else
+      replay_ids="$(
+        {
+          echo "$replay_ids"
+          echo "$ids_from_inspect"
+        } | tr ',' '\n' | awk 'NF' | sort -u | paste -sd, -
+      )"
+    fi
+
+    if MODE=replay MAX_MESSAGES=10 VISIBILITY_TIMEOUT_SECS=0 REPLAY_MESSAGE_IDS="$replay_ids" DRY_RUN=true \
+      AWS_REGION="$AWS_REGION" AWS_PROFILE="$AWS_PROFILE" STACK_NAME="$STACK_NAME" \
+      "$REPO_ROOT/scripts/dlq_ops.sh"; then
+      replay_match=true
+      break
+    fi
+
+    sleep 1
+  done
+
+  if [[ "$replay_match" != "true" ]]; then
+    echo "ERROR: dry-run replay validation could not match a current receive batch after retries" >&2
+    exit 1
+  fi
+
+  replay_sent=false
+  for attempt in 1 2 3 4 5; do
+    if MODE=replay MAX_MESSAGES=10 VISIBILITY_TIMEOUT_SECS=0 REPLAY_MESSAGE_IDS="$replay_ids" DRY_RUN=false DELETE_AFTER_REPLAY="$DELETE_AFTER_REPLAY" \
+      AWS_REGION="$AWS_REGION" AWS_PROFILE="$AWS_PROFILE" STACK_NAME="$STACK_NAME" \
+      "$REPO_ROOT/scripts/dlq_ops.sh"; then
+      replay_sent=true
+      break
+    fi
+    sleep 1
+  done
+
+  if [[ "$replay_sent" != "true" ]]; then
+    echo "ERROR: real replay validation failed to match a current receive batch after retries" >&2
+    exit 1
+  fi
+
+  echo "  - PASS: replay workflow validated (ids=${replay_ids})"
+else
+  echo "[5/5] Skipped replay validation (RUN_REPLAY_VALIDATION=false)"
+fi
+
+echo "SUCCESS: Day 8 scenario suite completed"


### PR DESCRIPTION
This pull request introduces comprehensive Dead Letter Queue (DLQ) operational support for the delivery worker system, including new documentation, a robust DLQ triage and replay script, and updates to the engineering timeline and troubleshooting guides. The main focus is to enable safe inspection, root-cause analysis, and controlled replay of failed messages, with clear operator guidance and safety protocols.

**DLQ Operations and Automation**

* Added a new script `scripts/dlq_ops.sh` for DLQ triage and replay, supporting inspection, root-cause summary, and safe message replay (dry-run and real modes) with AWS and DynamoDB integration.
* The runbook (`docs/runbook.md`) provides detailed step-by-step instructions for DLQ inspection, replay options, safety checks, and operational protocols, including command cookbook and escalation paths.

**Documentation and Operator Guidance**

* Updated the engineering timeline (`docs/ENGINEER_2_TIMELINE.md`) to mark DLQ script, runbook, troubleshooting guide, and resilience hardening as completed, reflecting new operational capabilities. [[1]](diffhunk://#diff-22ecc3dbdef666f8f25efce96997f4e2e0139ec2ba129af9e91530de5e1980ddL291-R310) [[2]](diffhunk://#diff-22ecc3dbdef666f8f25efce96997f4e2e0139ec2ba129af9e91530de5e1980ddL444-R445)
* Added a troubleshooting guide (`docs/troubleshooting.md`) with error-class playbooks, symptom checklists, and escalation paths for common delivery worker and DLQ issues.
* Updated the worker runtime documentation (`docs/WORKER_RUNTIME.md`) to reference the new DLQ runbook for triage and replay workflows.