### PR TITLE
Feat/merge loadtest docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,35 @@ flowchart TD
     Y --> Z[Delete message]
     Z --> A
 ```
+
+## Load Testing (k6)
+
+The shared load test script lives in `tests/load_test.js` and supports multiple
+profiles:
+
+- `MODE=steady` for constant-arrival-rate tests (default)
+- `MODE=ramping` for ramp-up/ramp-down VU stages
+- `MODE=seed` + `TARGET_EVENTS=...` for fixed-volume seeding
+
+Key environment variables:
+
+- `API_URL` (or `BASE_URL`) — ingestion API base URL
+- `API_KEY` — API Gateway key (if required)
+- `CUSTOMER_ID` — test customer ID
+- `SUMMARY_JSON_PATH` — optional JSON summary output path
+
+Example runs:
+
+```bash
+# Constant-arrival test at 500 req/sec for 2 minutes
+API_URL="https://<api-id>.execute-api.<region>.amazonaws.com/Prod" \
+MODE=steady RATE=500 DURATION=2m \
+SUMMARY_JSON_PATH="tests/loadtest-summary.json" \
+k6 run tests/load_test.js
+
+# Fixed-volume seed run (useful for worker-side throughput checks)
+API_URL="https://<api-id>.execute-api.<region>.amazonaws.com/Prod" \
+MODE=seed TARGET_EVENTS=1000 ITERATION_VUS=50 \
+SUMMARY_JSON_PATH="tests/loadtest-summary.json" \
+k6 run tests/load_test.js
+```

--- a/docs/ENGINEER_1_TIMELINE.md
+++ b/docs/ENGINEER_1_TIMELINE.md
@@ -238,9 +238,10 @@
 **Goal:** Validate performance under load
 
 **Tasks:**
-- [x] Create k6 load test script in `tests/load_test.js`
-- [ ] Run load test targeting 500 req/sec
-- [ ] Monitor CloudWatch metrics during test
+- [x] Create shared k6 load test script in `tests/load_test.js` (merged with Engineer 2)
+- [ ] Run load test targeting 500 req/sec (`MODE=steady`) or ramping VUs (`MODE=ramping`)
+- [ ] Capture structured summary output (`SUMMARY_JSON_PATH=...`) and share results
+- [ ] Monitor CloudWatch metrics during test (ingestion latency + accept/duplicate rates)
 - [ ] Identify bottlenecks
 - [ ] Optimize slow code paths
 - [ ] Add caching if beneficial

--- a/docs/ENGINEER_1_TIMELINE.md
+++ b/docs/ENGINEER_1_TIMELINE.md
@@ -238,7 +238,7 @@
 **Goal:** Validate performance under load
 
 **Tasks:**
-- [ ] Create k6 load test script in `tests/load_test.js`
+- [x] Create k6 load test script in `tests/load_test.js`
 - [ ] Run load test targeting 500 req/sec
 - [ ] Monitor CloudWatch metrics during test
 - [ ] Identify bottlenecks

--- a/docs/ENGINEER_2_TIMELINE.md
+++ b/docs/ENGINEER_2_TIMELINE.md
@@ -328,11 +328,15 @@
 **Goal:** Validate worker performance under load
 
 **Tasks:**
-- [ ] Load test setup:
-  - Generate 1000 events in SQS
-  - Monitor processing rate
-  - Track success/failure rates
-  - Measure end-to-end latency
+- [ ] Align on shared k6 script in `tests/load_test.js` (merged with Engineer 1):
+  - Supports `MODE=steady|ramping|seed` (constant-arrival, ramping VUs, or fixed-volume seeding)
+  - Emits summary JSON via `SUMMARY_JSON_PATH` for easy sharing
+  - Tracks accepted/duplicate/server-error rates + p95 latency
+- [ ] Load test setup (worker focus):
+  - Use `MODE=seed` + `TARGET_EVENTS=1000` to preload SQS
+  - Monitor processing rate + queue depth
+  - Track success/failure rates and retry/exhausted counts
+  - Measure end-to-end delivery latency
 - [ ] Identify bottlenecks:
   - DynamoDB read/write latency
   - HTTP delivery latency

--- a/ingestion/README.md
+++ b/ingestion/README.md
@@ -23,6 +23,7 @@
 12. [Roadmap — Week 2](#12-roadmap--week-2)
 13. [Day 6 — CloudWatch Observability](#13-day-6--cloudwatch-observability)
 14. [Reliability Fix — Orphaned Event Reconciliation](#14-reliability-fix--orphaned-event-reconciliation)
+15. [Day 9 — Load Testing (In Progress)](#15-day-9--load-testing-in-progress)
 
 ---
 
@@ -600,9 +601,9 @@ cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 | Day | Topic | Goal |
 |---|---|---|
 | 6 | CloudWatch dashboards | Webhook receive rate, idempotency hit %, error rates, p95 latency | ✅ |
-| 7 | API documentation | OpenAPI spec, customer onboarding guide, Postman collection | |
-| 8 | CI/CD pipeline | GitHub Actions: test → fmt → clippy → `sam deploy` to staging on merge | |
-| 9 | Load testing | k6 at 500 req/sec, < 100ms p95, < 0.1% error rate | |
+| 7 | API documentation | OpenAPI spec, customer onboarding guide, Postman collection | ✅ |
+| 8 | CI/CD pipeline | GitHub Actions: test → fmt → clippy → `sam deploy` to staging on merge | ✅ |
+| 9 | Load testing | k6 at 500 req/sec, < 100ms p95, < 0.1% error rate | ⏳ |
 | 10 | Final polish | README, demo script, tag v1.0.0 | |
 
 ### Known technical debt
@@ -787,6 +788,34 @@ cargo run -p ingestion --bin reconcile_orphaned
 
 The runner re-enqueues only **pending** events with `attempt_count == 0`, and
 clears the orphaned marker after a successful re-queue.
+
+---
+
+## 15. Day 9 — Load Testing (In Progress)
+
+### Goal
+
+Validate 500 req/sec sustained throughput with <$100ms p95 latency and
+<0.1% error rate.
+
+### Load test script
+
+`tests/load_test.js` is a k6 script that targets `POST /webhooks/receive` with a
+constant-arrival-rate scenario and configurable parameters.
+
+### How to run
+
+```
+BASE_URL="https://<api-id>.execute-api.us-west-2.amazonaws.com/Prod" \
+API_KEY="apk_your_key" \
+CUSTOMER_ID="cust_loadtest" \
+SETUP_CREATE_CONFIG=true \
+k6 run tests/load_test.js
+```
+
+Use `RATE`, `DURATION`, `PRE_ALLOCATED_VUS`, and `MAX_VUS` env vars to tune load.
+Results are pending until the full run is executed and CloudWatch metrics are
+captured.
 
 `start` is a `std::time::Instant` captured at handler entry — no async overhead,
 no extra allocations on the hot path.

--- a/tests/load_test.js
+++ b/tests/load_test.js
@@ -1,20 +1,80 @@
 import http from "k6/http";
-import { check } from "k6";
-import { randomUUID } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
+import { check, sleep } from "k6";
+import { Counter, Rate } from "k6/metrics";
+import { uuidv4 } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
 
-const BASE_URL = __ENV.BASE_URL;
-const API_KEY = __ENV.API_KEY;
-const CUSTOMER_ID = __ENV.CUSTOMER_ID || "cust_loadtest";
+const API_URL = (__ENV.API_URL || __ENV.BASE_URL || "").replace(/\/+$/, "");
+const API_KEY = __ENV.API_KEY || "";
+const CUSTOMER_ID = __ENV.CUSTOMER_ID || "load_test_customer";
 const TARGET_URL = __ENV.TARGET_URL || "https://httpbin.org/post";
+const TEST_RUN_ID = __ENV.TEST_RUN_ID || `run_${Date.now()}`;
+const ENDPOINT_PROFILE = __ENV.ENDPOINT_PROFILE || "healthy";
+
+const TARGET_EVENTS = Number(__ENV.TARGET_EVENTS || 0);
+const ITERATION_VUS = Number(__ENV.ITERATION_VUS || 50);
+const MODE = __ENV.MODE || (TARGET_EVENTS > 0 ? "seed" : "steady");
 
 const RATE = Number(__ENV.RATE || 500);
 const DURATION = __ENV.DURATION || "2m";
 const PREALLOCATED_VUS = Number(__ENV.PRE_ALLOCATED_VUS || 200);
 const MAX_VUS = Number(__ENV.MAX_VUS || 400);
+const THINK_TIME_MS = Number(__ENV.THINK_TIME_MS || 250);
 const SETUP_CREATE_CONFIG = __ENV.SETUP_CREATE_CONFIG === "true";
 
-export const options = {
-  scenarios: {
+const successRate = new Rate("accepted_rate");
+const duplicateRate = new Rate("duplicate_rate");
+const serverErrorRate = new Rate("server_error_rate");
+const statusAccepted = new Counter("status_accepted");
+const statusDuplicate = new Counter("status_duplicate");
+
+const httpReqFailedThreshold = __ENV.HTTP_REQ_FAILED_THRESHOLD || "rate<0.001";
+const httpReqDurationP95Threshold =
+  __ENV.HTTP_REQ_DURATION_P95_THRESHOLD || "p(95)<500";
+const acceptedRateThreshold = __ENV.ACCEPTED_RATE_THRESHOLD || "rate>0.99";
+const serverErrorRateThreshold =
+  __ENV.SERVER_ERROR_RATE_THRESHOLD || "rate<0.005";
+
+function buildScenarios() {
+  if (MODE === "seed" || TARGET_EVENTS > 0) {
+    return {
+      ingestion_seed: {
+        executor: "shared-iterations",
+        vus: ITERATION_VUS,
+        iterations: TARGET_EVENTS,
+        maxDuration: __ENV.MAX_DURATION || "30m",
+      },
+    };
+  }
+
+  if (MODE === "ramping") {
+    return {
+      ingestion_load: {
+        executor: "ramping-vus",
+        startVUs: Number(__ENV.START_VUS || 0),
+        stages: [
+          {
+            duration: __ENV.STAGE_1_DURATION || "1m",
+            target: Number(__ENV.STAGE_1_TARGET || 10),
+          },
+          {
+            duration: __ENV.STAGE_2_DURATION || "3m",
+            target: Number(__ENV.STAGE_2_TARGET || 50),
+          },
+          {
+            duration: __ENV.STAGE_3_DURATION || "5m",
+            target: Number(__ENV.STAGE_3_TARGET || 100),
+          },
+          {
+            duration: __ENV.STAGE_4_DURATION || "1m",
+            target: Number(__ENV.STAGE_4_TARGET || 0),
+          },
+        ],
+        gracefulRampDown: __ENV.GRACEFUL_RAMP_DOWN || "30s",
+      },
+    };
+  }
+
+  return {
     steady: {
       executor: "constant-arrival-rate",
       rate: RATE,
@@ -23,10 +83,20 @@ export const options = {
       preAllocatedVUs: PREALLOCATED_VUS,
       maxVUs: MAX_VUS,
     },
-  },
+  };
+}
+
+export const options = {
+  scenarios: buildScenarios(),
   thresholds: {
-    http_req_failed: ["rate<0.001"],
-    http_req_duration: ["p(95)<100"],
+    http_req_failed: [httpReqFailedThreshold],
+    http_req_duration: [httpReqDurationP95Threshold],
+    accepted_rate: [acceptedRateThreshold],
+    server_error_rate: [serverErrorRateThreshold],
+  },
+  tags: {
+    test_run_id: TEST_RUN_ID,
+    endpoint_profile: ENDPOINT_PROFILE,
   },
 };
 
@@ -39,8 +109,10 @@ function buildHeaders() {
 }
 
 export function setup() {
-  if (!BASE_URL) {
-    throw new Error("BASE_URL env var is required (e.g. https://<api-id>.execute-api.us-west-2.amazonaws.com/Prod)");
+  if (!API_URL) {
+    throw new Error(
+      "API_URL or BASE_URL env var is required (e.g. https://<api-id>.execute-api.us-west-2.amazonaws.com/Prod)",
+    );
   }
 
   if (SETUP_CREATE_CONFIG) {
@@ -48,7 +120,7 @@ export function setup() {
       customer_id: CUSTOMER_ID,
       url: TARGET_URL,
     });
-    const res = http.post(`${BASE_URL}/webhooks/configs`, configBody, {
+    const res = http.post(`${API_URL}/webhooks/configs`, configBody, {
       headers: buildHeaders(),
       tags: { endpoint: "configs" },
     });
@@ -61,22 +133,122 @@ export function setup() {
 }
 
 export default function (data) {
-  const payload = {
-    idempotency_key: `load_${randomUUID()}`,
+  const payload = JSON.stringify({
+    idempotency_key: `req_${uuidv4()}`,
     customer_id: data.customerId,
     data: {
+      event_type: "load_test_event",
+      test_run_id: TEST_RUN_ID,
+      endpoint_profile: ENDPOINT_PROFILE,
       source: "k6",
       seq: `${__VU}-${__ITER}`,
       ts: Date.now(),
+      order_id: `ord_${uuidv4()}`,
+      amount: Math.round(Math.random() * 100000) / 100,
+      created_at_ms: Date.now(),
     },
-  };
+  });
 
-  const res = http.post(`${BASE_URL}/webhooks/receive`, JSON.stringify(payload), {
+  const res = http.post(`${API_URL}/webhooks/receive`, payload, {
     headers: buildHeaders(),
     tags: { endpoint: "receive" },
   });
 
+  const body = res.body
+    ? (() => {
+        try {
+          return JSON.parse(res.body);
+        } catch (_) {
+          return {};
+        }
+      })()
+    : {};
+
+  const isAccepted =
+    res.status === 202 &&
+    body.status === "accepted" &&
+    typeof body.event_id === "string";
+  const isDuplicate =
+    res.status === 200 &&
+    body.status === "duplicate" &&
+    typeof body.event_id === "string";
+  const isServerError = res.status >= 500;
+
+  if (isAccepted) {
+    statusAccepted.add(1);
+  }
+  if (isDuplicate) {
+    statusDuplicate.add(1);
+  }
+
+  successRate.add(isAccepted);
+  duplicateRate.add(isDuplicate);
+  serverErrorRate.add(isServerError);
+
   check(res, {
-    "receive accepted/duplicate": (r) => r.status === 200 || r.status === 202,
+    "status is 202 or 200": (r) => r.status === 202 || r.status === 200,
+    "response includes event_id": () => typeof body.event_id === "string",
+    "status is accepted or duplicate":
+      () => body.status === "accepted" || body.status === "duplicate",
   });
+
+  if (MODE === "ramping") {
+    sleep(THINK_TIME_MS / 1000);
+  }
+}
+
+function metricValue(data, name, stat = "value") {
+  const metric = data.metrics?.[name];
+  if (!metric) return null;
+
+  if (metric.values && Object.prototype.hasOwnProperty.call(metric.values, stat)) {
+    return metric.values[stat];
+  }
+
+  return null;
+}
+
+export function handleSummary(data) {
+  const summary = {
+    meta: {
+      generated_at: new Date().toISOString(),
+      api_url: API_URL,
+      customer_id: CUSTOMER_ID,
+      test_run_id: TEST_RUN_ID,
+      endpoint_profile: ENDPOINT_PROFILE,
+      mode: MODE,
+      target_events: TARGET_EVENTS,
+      iteration_vus: TARGET_EVENTS > 0 ? ITERATION_VUS : null,
+      rate: MODE === "steady" ? RATE : null,
+      duration: MODE === "steady" ? DURATION : null,
+    },
+    metrics: {
+      accepted_rate: metricValue(data, "accepted_rate", "rate"),
+      duplicate_rate: metricValue(data, "duplicate_rate", "rate"),
+      server_error_rate: metricValue(data, "server_error_rate", "rate"),
+      http_req_failed_rate: metricValue(data, "http_req_failed", "rate"),
+      http_req_duration_p95_ms: metricValue(data, "http_req_duration", "p(95)"),
+      iterations: metricValue(data, "iterations", "count"),
+      status_accepted: metricValue(data, "status_accepted", "count"),
+      status_duplicate: metricValue(data, "status_duplicate", "count"),
+    },
+  };
+
+  const outPath = __ENV.SUMMARY_JSON_PATH || "";
+  const rendered = JSON.stringify(summary, null, 2);
+
+  const outputs = {
+    stdout:
+      `\n=== k6 load test summary ===\n` +
+      `test_run_id: ${TEST_RUN_ID}\n` +
+      `mode: ${MODE}\n` +
+      `target_events: ${TARGET_EVENTS || "ramping/steady"}\n` +
+      `${rendered}\n`,
+  };
+
+  if (outPath) {
+    outputs[outPath] = rendered;
+  }
+
+  return outputs;
 }

--- a/tests/load_test.js
+++ b/tests/load_test.js
@@ -1,0 +1,82 @@
+import http from "k6/http";
+import { check } from "k6";
+import { randomUUID } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
+
+const BASE_URL = __ENV.BASE_URL;
+const API_KEY = __ENV.API_KEY;
+const CUSTOMER_ID = __ENV.CUSTOMER_ID || "cust_loadtest";
+const TARGET_URL = __ENV.TARGET_URL || "https://httpbin.org/post";
+
+const RATE = Number(__ENV.RATE || 500);
+const DURATION = __ENV.DURATION || "2m";
+const PREALLOCATED_VUS = Number(__ENV.PRE_ALLOCATED_VUS || 200);
+const MAX_VUS = Number(__ENV.MAX_VUS || 400);
+const SETUP_CREATE_CONFIG = __ENV.SETUP_CREATE_CONFIG === "true";
+
+export const options = {
+  scenarios: {
+    steady: {
+      executor: "constant-arrival-rate",
+      rate: RATE,
+      timeUnit: "1s",
+      duration: DURATION,
+      preAllocatedVUs: PREALLOCATED_VUS,
+      maxVUs: MAX_VUS,
+    },
+  },
+  thresholds: {
+    http_req_failed: ["rate<0.001"],
+    http_req_duration: ["p(95)<100"],
+  },
+};
+
+function buildHeaders() {
+  const headers = { "Content-Type": "application/json" };
+  if (API_KEY) {
+    headers["X-API-Key"] = API_KEY;
+  }
+  return headers;
+}
+
+export function setup() {
+  if (!BASE_URL) {
+    throw new Error("BASE_URL env var is required (e.g. https://<api-id>.execute-api.us-west-2.amazonaws.com/Prod)");
+  }
+
+  if (SETUP_CREATE_CONFIG) {
+    const configBody = JSON.stringify({
+      customer_id: CUSTOMER_ID,
+      url: TARGET_URL,
+    });
+    const res = http.post(`${BASE_URL}/webhooks/configs`, configBody, {
+      headers: buildHeaders(),
+      tags: { endpoint: "configs" },
+    });
+    check(res, {
+      "config create success": (r) => r.status === 200 || r.status === 201,
+    });
+  }
+
+  return { customerId: CUSTOMER_ID };
+}
+
+export default function (data) {
+  const payload = {
+    idempotency_key: `load_${randomUUID()}`,
+    customer_id: data.customerId,
+    data: {
+      source: "k6",
+      seq: `${__VU}-${__ITER}`,
+      ts: Date.now(),
+    },
+  };
+
+  const res = http.post(`${BASE_URL}/webhooks/receive`, JSON.stringify(payload), {
+    headers: buildHeaders(),
+    tags: { endpoint: "receive" },
+  });
+
+  check(res, {
+    "receive accepted/duplicate": (r) => r.status === 200 || r.status === 202,
+  });
+}


### PR DESCRIPTION
Summary
merge the shared k6 load test features into load_test.js (steady/ramping/seed modes, richer metrics, summary output)
align Day 9 timelines for both engineers with the unified load test plan
document the shared load test workflow in the root README.md

Notes
Script supports API_URL or BASE_URL and optional SUMMARY_JSON_PATH for JSON output
Use MODE=steady|ramping|seed depending on ingestion throughput vs worker seed runs